### PR TITLE
Fix bug in shared memory channel

### DIFF
--- a/dds-protocol-lib/src/BaseSMChannelImpl.h
+++ b/dds-protocol-lib/src/BaseSMChannelImpl.h
@@ -111,13 +111,13 @@ namespace dds
                     m_transportIn =
                         std::make_shared<boost::interprocess::message_queue>(boost::interprocess::open_or_create,
                                                                              m_inputMessageQueueName.c_str(),
-                                                                             maxMessageSize,
-                                                                             maxNofMessages);
+                                                                             maxNofMessages,
+                                                                             maxMessageSize);
                     m_transportOut =
                         std::make_shared<boost::interprocess::message_queue>(boost::interprocess::open_or_create,
                                                                              m_outputMessageQueueName.c_str(),
-                                                                             maxMessageSize,
-                                                                             maxNofMessages);
+                                                                             maxNofMessages,
+                                                                             maxMessageSize);
                 }
                 catch (boost::interprocess::interprocess_exception& _e)
                 {


### PR DESCRIPTION
Due to a wrong order of the parameters in the constructor it was not possible to send messages more than 100 bytes in shared memory channel.