### PR TITLE
dds-topology: fix --disable-validation option

### DIFF
--- a/dds-commander/src/ConnectionManager.cpp
+++ b/dds-commander/src/ConnectionManager.cpp
@@ -526,7 +526,7 @@ void CConnectionManager::on_cmdUPDATE_TOPOLOGY(const SSenderInfo& _sender,
         // If topo file is empty than we stop the topology
         if (!_attachment->m_sTopologyFile.empty())
         {
-            topo.setXMLValidationDisabled(_attachment->m_nDisiableValidation);
+            topo.setXMLValidationDisabled(_attachment->m_nDisableValidation);
             topo.init(_attachment->m_sTopologyFile);
         }
 

--- a/dds-protocol-lib/src/UpdateTopologyCmd.cpp
+++ b/dds-protocol-lib/src/UpdateTopologyCmd.cpp
@@ -12,7 +12,7 @@ using namespace dds::protocol_api;
 namespace inet = MiscCommon::INet;
 
 SUpdateTopologyCmd::SUpdateTopologyCmd()
-    : m_nDisiableValidation(0)
+    : m_nDisableValidation(0)
     , m_sTopologyFile()
     , m_updateType((uint8_t)EUpdateType::UPDATE)
 {
@@ -20,29 +20,29 @@ SUpdateTopologyCmd::SUpdateTopologyCmd()
 
 size_t SUpdateTopologyCmd::size() const
 {
-    return dsize(m_sTopologyFile) + dsize(m_nDisiableValidation) + dsize(m_updateType);
+    return dsize(m_sTopologyFile) + dsize(m_nDisableValidation) + dsize(m_updateType);
 }
 
 bool SUpdateTopologyCmd::operator==(const SUpdateTopologyCmd& val) const
 {
-    return (m_sTopologyFile == val.m_sTopologyFile && m_nDisiableValidation == val.m_nDisiableValidation &&
+    return (m_sTopologyFile == val.m_sTopologyFile && m_nDisableValidation == val.m_nDisableValidation &&
             m_updateType == val.m_updateType);
 }
 
 void SUpdateTopologyCmd::_convertFromData(const MiscCommon::BYTEVector_t& _data)
 {
-    SAttachmentDataProvider(_data).get(m_nDisiableValidation).get(m_sTopologyFile).get(m_updateType);
+    SAttachmentDataProvider(_data).get(m_nDisableValidation).get(m_sTopologyFile).get(m_updateType);
 }
 
 void SUpdateTopologyCmd::_convertToData(MiscCommon::BYTEVector_t* _data) const
 {
-    SAttachmentDataProvider(_data).put(m_nDisiableValidation).put(m_sTopologyFile).put(m_updateType);
+    SAttachmentDataProvider(_data).put(m_nDisableValidation).put(m_sTopologyFile).put(m_updateType);
 }
 
 std::ostream& dds::protocol_api::operator<<(std::ostream& _stream, const SUpdateTopologyCmd& val)
 {
     return _stream << "topo file: " << val.m_sTopologyFile << "; validation "
-                   << (val.m_nDisiableValidation ? "disabled" : "enabled") << "update type: " << val.m_updateType;
+                   << (val.m_nDisableValidation ? "disabled" : "enabled") << "update type: " << val.m_updateType;
 }
 bool dds::protocol_api::operator!=(const SUpdateTopologyCmd& lhs, const SUpdateTopologyCmd& rhs)
 {

--- a/dds-protocol-lib/src/UpdateTopologyCmd.h
+++ b/dds-protocol-lib/src/UpdateTopologyCmd.h
@@ -28,7 +28,7 @@ namespace dds
             bool operator==(const SUpdateTopologyCmd& val) const;
 
             // when 0 - valiadate, any other value - don't validate
-            uint16_t m_nDisiableValidation;
+            uint16_t m_nDisableValidation;
             // topology file
             std::string m_sTopologyFile;
             // topology update type

--- a/dds-topology/src/ActivateChannel.cpp
+++ b/dds-topology/src/ActivateChannel.cpp
@@ -35,7 +35,7 @@ CActivateChannel::CActivateChannel(boost::asio::io_service& _service, uint64_t _
                 LOG(MiscCommon::log_stdout) << "Requesting server to activate/update/stop a topology...";
                 SUpdateTopologyCmd cmd;
                 cmd.m_sTopologyFile = m_options.m_sTopoFile;
-                cmd.m_nDisiableValidation = m_options.m_bDisiableValidation;
+                cmd.m_nDisableValidation = m_options.m_bDisableValidation;
                 // Set the proper update type
                 if (m_options.m_topologyCmd == ETopologyCmdType::ACTIVATE)
                     cmd.m_updateType = (uint8_t)SUpdateTopologyCmd::EUpdateType::ACTIVATE;

--- a/dds-topology/src/Options.h
+++ b/dds-topology/src/Options.h
@@ -37,14 +37,14 @@ namespace dds
             SOptions()
                 : m_topologyCmd(ETopologyCmdType::UNKNOWN)
                 , m_verbose(false)
-                , m_bDisiableValidation(false)
+                , m_bDisableValidation(false)
             {
             }
 
             ETopologyCmdType m_topologyCmd;
             std::string m_sTopoFile;
             bool m_verbose;
-            bool m_bDisiableValidation;
+            bool m_bDisableValidation;
         } SOptions_t;
         //=============================================================================
         inline void PrintVersion()
@@ -69,8 +69,8 @@ namespace dds
                                   bpo::value<std::string>(&_options->m_sTopoFile),
                                   "Define a topology to update currently active topology.");
             options.add_options()("disable-validation",
-                                  bpo::bool_switch(&_options->m_bDisiableValidation),
-                                  "Disiable topology valiadation.");
+                                  bpo::bool_switch(&_options->m_bDisableValidation),
+                                  "Disable topology valiadation.");
             options.add_options()("activate",
                                   bpo::value<std::string>(&_options->m_sTopoFile),
                                   "Request to activate agents, i.e. distribute and start user tasks.");
@@ -103,7 +103,7 @@ namespace dds
             {
                 _options->m_verbose = true;
             }
-            if (vm.count("disable-validation") && _options->m_bDisiableValidation)
+            if (_options->m_bDisableValidation)
             {
                 if (!vm.count("activate") && !vm.count("update"))
                 {


### PR DESCRIPTION
The disable-validation check was always triggered preventing the user
from using e.g. --stop. This patch also fixes a typo in the variable
names in dds-topology, dds-protocol-lib, and dds-commander.

---

Note: I created this patch against DDS 1.6. In `master` the problem was already fixed. But I still propose my patch because it fixes a typo and drops `vm.count("disable-validation")` which always returns `1`.