### PR TITLE
Fix -Wreturn-type and small bug in dds-session

### DIFF
--- a/dds-protocol-lib/src/BaseSMChannelImpl.h
+++ b/dds-protocol-lib/src/BaseSMChannelImpl.h
@@ -256,6 +256,11 @@ namespace dds
                         case EMQOpenType::OpenOnly:
                             return std::make_shared<boost::interprocess::message_queue>(boost::interprocess::open_only,
                                                                                         _name.c_str());
+                        default:
+                            LOG(MiscCommon::error)
+                                << "Can't initialize shared memory transport with name " << _name << ": "
+                                << "Unknown EMQOpenType given: " << static_cast<int>(_openType);
+                            return nullptr;
                     }
                 }
                 catch (boost::interprocess::interprocess_exception& _e)

--- a/dds-session/src/Start.cpp
+++ b/dds-session/src/Start.cpp
@@ -98,7 +98,7 @@ bool CStart::checkPrecompiledWNBins(bool _onlyLocalSys)
         LOG(log_stdout_clean) << "Checking precompiled binaries for the local system only:";
         stringstream ssName;
         ssName << sBaseName << "-" << PROJECT_VERSION_STRING << "-" << sOS << "-"
-               << (sOS == sOSXArch ? "universal" : sOSXArch) << sBaseSufix;
+               << (sOS == sOSXArch ? "universal" : sArch) << sBaseSufix;
         // Check availability
         fs::path pathBin(pathWnBins);
         pathBin /= ssName.str();


### PR DESCRIPTION
`warning: control reaches end of non-void function`
reported by gcc 8.1.1

Full log:

```
╭─dklein@gamma ~/projects/DDS/build  ‹master*› 
╰─➤  cmake -GNinja -DCMAKE_PREFIX_PATH=/home/dklein/fairsoft_may18 -DCMAKE_INSTALL_PREFIX=./install ..
-- The C compiler identification is GNU 8.1.1
-- The CXX compiler identification is GNU 8.1.1
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Building DDS version: 2.1.16.gfed711b
-- Found Doxygen: /usr/bin/doxygen (found version "1.8.14") found components:  doxygen dot 
-- Build API docs - YES
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Looking for pthread_create
-- Looking for pthread_create - not found
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Boost version: 1.67.0
-- Found the following Boost libraries:
--   log
--   log_setup
--   thread
--   program_options
--   filesystem
--   system
--   regex
--   signals
--   date_time
--   chrono
--   atomic
-- Build MiscCommon - YES
-- Build the dds_sys_files lib - YES
-- Build the dds_ncf lib - YES
-- Build dds_ncf unit tests - NO
-- Build MiscCommon unit tests - NO
-- Build dds_protocol_lib - YES
-- Build dds_protocol_lib tests - NO
-- Build dds-daemonize - YES
-- Build dds-daemonize unit tests - NO
-- Build dds-commander - YES
-- Build dds-commander unit tests - NO
-- Build dds-topology - YES
-- Build dds_topology_lib - YES
-- Build dds_topology_lib unit tests - NO
-- Build dds-agent - YES
-- Build dds-agent unit tests - NO
-- Build dds-user-defaults - YES
-- Build dds-user-defaults unit tests - NO
-- Build dds-info - YES
-- Build dds-submit - YES
-- Build dds-agent-cmd - YES
-- Build dds-test - YES
-- Build dds-octopus - YES
-- Build dds-tutorials - YES
-- Build Tutorial1 - YES
-- Build Tutorial2 - YES
-- Build Tutorial3 - YES
-- Build dds-stat - YES
-- Build dds-custom-cmd - YES
-- Build dds_intercom_lib - YES
-- Build dds_intercom_lib tests - NO
-- Build dds-submit-ssh - YES
-- Build dds-submit-ssh unit tests - NO
-- Build dds-submit-localhost - YES
-- Build dds-submit-slurm - YES
-- Build dds-submit-pbs - YES
-- Build dds-submit-lsf - YES
-- Build dds-session - YES
-- Configuring done
-- Generating done
-- Build files have been written to: /home/dklein/projects/DDS/build
╭─dklein@gamma ~/projects/DDS/build  ‹master*› 
╰─➤  cmake --build . 
[57/129] Building CXX object dds-agent/CMakeFiles/dds-agent.dir/src/SMUIChannel.cpp.o
In file included from ../dds-agent/src/SMUIChannel.h:9,
                 from ../dds-agent/src/SMUIChannel.cpp:7:
../dds-protocol-lib/src/BaseSMChannelImpl.h: In member function ‘dds::protocol_api::CBaseSMChannelImpl<T>::messageQueuePtr_t dds::protocol_api::CBaseSMChannelImpl<T>::createMessageQueue(const string&, dds::protocol_api::EMQOpenType) [with T = dds::CSMUIChannel]’:
../dds-protocol-lib/src/BaseSMChannelImpl.h:267:13: warning: control reaches end of non-void function [-Wreturn-type]
             }
             ^
[58/129] Building CXX object dds-agent/CMakeFiles/dds-agent.dir/src/SMFWChannel.cpp.o
In file included from ../dds-agent/src/SMFWChannel.h:9,
                 from ../dds-agent/src/SMFWChannel.cpp:7:
../dds-protocol-lib/src/BaseSMChannelImpl.h: In member function ‘dds::protocol_api::CBaseSMChannelImpl<T>::messageQueuePtr_t dds::protocol_api::CBaseSMChannelImpl<T>::createMessageQueue(const string&, dds::protocol_api::EMQOpenType) [with T = dds::CSMFWChannel]’:
../dds-protocol-lib/src/BaseSMChannelImpl.h:267:13: warning: control reaches end of non-void function [-Wreturn-type]
             }
             ^
[66/129] Building CXX object dds-agent/CMakeFiles/dds-agent.dir/src/SMLeaderChannel.cpp.o
In file included from ../dds-agent/src/SMLeaderChannel.h:9,
                 from ../dds-agent/src/SMLeaderChannel.cpp:7:
../dds-protocol-lib/src/BaseSMChannelImpl.h: In member function ‘dds::protocol_api::CBaseSMChannelImpl<T>::messageQueuePtr_t dds::protocol_api::CBaseSMChannelImpl<T>::createMessageQueue(const string&, dds::protocol_api::EMQOpenType) [with T = dds::CSMLeaderChannel]’:
../dds-protocol-lib/src/BaseSMChannelImpl.h:267:13: warning: control reaches end of non-void function [-Wreturn-type]
             }
             ^
[69/129] Building CXX object dds-agent/CMakeFiles/dds-agent.dir/src/SMCommanderChannel.cpp.o
In file included from ../dds-agent/src/SMCommanderChannel.h:9,
                 from ../dds-agent/src/SMCommanderChannel.cpp:7:
../dds-protocol-lib/src/BaseSMChannelImpl.h: In member function ‘dds::protocol_api::CBaseSMChannelImpl<T>::messageQueuePtr_t dds::protocol_api::CBaseSMChannelImpl<T>::createMessageQueue(const string&, dds::protocol_api::EMQOpenType) [with T = dds::CSMCommanderChannel]’:
../dds-protocol-lib/src/BaseSMChannelImpl.h:267:13: warning: control reaches end of non-void function [-Wreturn-type]
             }
             ^
[70/129] Building CXX object dds-agent/CMakeFiles/dds-agent.dir/src/AgentConnectionManager.cpp.o
In file included from ../dds-agent/src/SMFWChannel.h:9,
                 from ../dds-agent/src/CommanderChannel.h:11,
                 from ../dds-agent/src/AgentConnectionManager.h:10,
                 from ../dds-agent/src/AgentConnectionManager.cpp:13:
../dds-protocol-lib/src/BaseSMChannelImpl.h: In member function ‘dds::protocol_api::CBaseSMChannelImpl<T>::messageQueuePtr_t dds::protocol_api::CBaseSMChannelImpl<T>::createMessageQueue(const string&, dds::protocol_api::EMQOpenType) [with T = dds::CSMCommanderChannel]’:
../dds-protocol-lib/src/BaseSMChannelImpl.h:267:13: warning: control reaches end of non-void function [-Wreturn-type]
             }
             ^
../dds-protocol-lib/src/BaseSMChannelImpl.h: In member function ‘dds::protocol_api::CBaseSMChannelImpl<T>::messageQueuePtr_t dds::protocol_api::CBaseSMChannelImpl<T>::createMessageQueue(const string&, dds::protocol_api::EMQOpenType) [with T = dds::CSMFWChannel]’:
../dds-protocol-lib/src/BaseSMChannelImpl.h:267:13: warning: control reaches end of non-void function [-Wreturn-type]
             }
             ^
[102/129] Building CXX object dds-intercom-lib/CMakeFiles/dds_intercom_lib.dir/src/DDSIntercomGuard.cpp.o
In file included from ../dds-intercom-lib/src/SMAgentChannel.h:9,
                 from ../dds-intercom-lib/src/DDSIntercomGuard.h:9,
                 from ../dds-intercom-lib/src/DDSIntercomGuard.cpp:6:
../dds-protocol-lib/src/BaseSMChannelImpl.h: In member function ‘dds::protocol_api::CBaseSMChannelImpl<T>::messageQueuePtr_t dds::protocol_api::CBaseSMChannelImpl<T>::createMessageQueue(const string&, dds::protocol_api::EMQOpenType) [with T = dds::internal_api::CSMAgentChannel]’:
../dds-protocol-lib/src/BaseSMChannelImpl.h:267:13: warning: control reaches end of non-void function [-Wreturn-type]
             }
             ^
[129/129] Linking CXX executable dds-session/dds-session
```