### PR TITLE
Fix issue when boost 1.70.0 has both static and shared libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@
 #
 #
 project( DDS )
+set(BUILD_SHARED_LIBS ON)
 
 set(USER_DEFAULTS_CFG_VERSION "0.2")
 set(DDS_PROTOCOL_VERSION "2")


### PR DESCRIPTION
This is required because the new config mechanism of 1.70.0
seems to prefer static libraries by default if BUILD_SHARED_LIBS
is not explicitly set, resulting in a bunch of undefined symbols
coming from the fact you use:

explicitly in DDS/MiscCommon/Logger.h . Not sure if this is the most
elegant solution, but it pragmatically works in my setup.