### PR TITLE
Fix dds-submit user ssh options

### DIFF
--- a/plugins/dds-submit-ssh/src/dds-submit-ssh-worker
+++ b/plugins/dds-submit-ssh/src/dds-submit-ssh-worker
@@ -38,8 +38,8 @@ SSH_CON_STR=""
 RDIR=""
 NWORKERS=1
 SSHOPT=""
-while getopts ":i:l:w:n:oh" opt; do
-  case $opt in
+while getopts "i:l:w:n:o:h" opt; do
+  case "$opt" in
   i)
     WORKER_ID="$OPTARG"
     ;;
@@ -110,7 +110,7 @@ logMsg()
 #=============================================================================
 # ***** MAIN *****
 #=============================================================================
-logMsg "$TOOL_NAME is started for $SSH_CON_STR (dir: $RDIR, nworkers: $NWORKERS, sshopt: $SSHOPT)"
+logMsg "$TOOL_NAME is started for $SSH_CON_STR (dir: $RDIR, nworkers: $NWORKERS, sshopt: \"$SSHOPT\")"
 
 # check that the worker package is ready
 if [ ! -r $WRK_S_L ]; then

--- a/plugins/dds-submit-ssh/src/main.cpp
+++ b/plugins/dds-submit-ssh/src/main.cpp
@@ -207,6 +207,10 @@ int main(int argc, char* argv[])
                     //     job slots to create
 
                     wrkCount += rec->m_nWorkers;
+
+                    stringstream ssWorkerInfoMsg;
+                    wrk.printInfo(ssWorkerInfoMsg);
+                    proto.sendMessage(dds::intercom_api::EMsgSeverity::info, ssWorkerInfoMsg.str());
                 }
             }
             stringstream ssMsg;

--- a/plugins/dds-submit-ssh/src/worker.cpp
+++ b/plugins/dds-submit-ssh/src/worker.cpp
@@ -51,16 +51,16 @@ bool CWorker::runTask(ETaskType _param) const
     boost::mutex::scoped_lock lck(*m_mutex);
 
     stringstream ssParams;
-    ssParams << " -i " << m_rec->m_id << " -l " << m_rec->m_addr << " -w " << m_rec->m_wrkDir;
+    ssParams << " -i \"" << m_rec->m_id << "\" -l \"" << m_rec->m_addr << "\" -w \"" << m_rec->m_wrkDir << "\"";
     if (!m_rec->m_sshOptions.empty())
-        ssParams << " -o " << m_rec->m_sshOptions;
+        ssParams << " -o \"" << m_rec->m_sshOptions << "\"";
 
     stringstream ssCmd;
     switch (_param)
     {
         case task_submit:
         {
-            ssParams << " -n " << m_rec->m_nWorkers;
+            ssParams << " -n \"" << m_rec->m_nWorkers << "\"";
             string cmd(m_path);
             cmd += "dds-submit-ssh-worker";
             smart_path(&cmd);

--- a/plugins/dds-submit-ssh/src/worker.cpp
+++ b/plugins/dds-submit-ssh/src/worker.cpp
@@ -91,6 +91,7 @@ bool CWorker::runTask(ETaskType _param) const
 //=============================================================================
 bool CWorker::exec_command(const string& _cmd) const
 {
+    log(_cmd);
     string outPut;
     try
     {


### PR DESCRIPTION
The first commit fixes a bug in the getopts config within the `dds-submit-ssh-worker` script which had the effect that, if a user ssh option was set, the `-n` argument passed after was not properly parsed (at least on Fedora 30 the script was always spawning exactly 1 agent in the presence of a `-o` option).

The second commit is obviously very optional, but I found it very useful. (If you don't like it, you can push to my branch and remove it or I can remove it)