### PR TITLE
dds-topology-lib: Add missing member function definition

### DIFF
--- a/dds-topology-lib/src/Topology.cpp
+++ b/dds-topology-lib/src/Topology.cpp
@@ -36,6 +36,11 @@ CTopoGroup::Ptr_t CTopology::getMainGroup() const
     return m_topo->getMainGroup();
 }
 
+std::string CTopology::getName() const
+{
+    return m_topo->getName();
+}
+
 const STopoRuntimeTask& CTopology::getRuntimeTaskById(Id_t _id) const
 {
     return m_topo->getRuntimeTaskById(_id);


### PR DESCRIPTION
I missed a function definition in #232, my bad :-( This fixes it.

```
/usr/bin/ld: fairmq/sdk/libFairMQ_SDK.so.1.4.5-87-g7d1ee82-dirty: undefined reference to `dds::topology_api::CTopology::getName[abi:cxx11]() const'
```