### PR TITLE
dds-intercom-lib: Fix thread leak

### DIFF
--- a/dds-intercom-lib/src/DDSIntercomGuard.cpp
+++ b/dds-intercom-lib/src/DDSIntercomGuard.cpp
@@ -57,6 +57,9 @@ CDDSIntercomGuard& CDDSIntercomGuard::instance()
 
 void CDDSIntercomGuard::start(const std::string& _sessionID)
 {
+    if (m_started)
+        return;
+
     // Choose transport type.
     // If we connect to agent, i.e. agent config file exists than we use shared memory transport.
     // If we connect to commander, i.e. commander config file exists we use asio transport.


### PR DESCRIPTION
It makes me also think, if we need threadsafety in this class? E.g. if the user sends a custom command reply directly in a callback which is executed on the thread pool?