### PR TITLE
Add --wait-for-executing-agents option

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -10,6 +10,9 @@ Added: parsing and reporting of the topology name: "dds-info --active-topology",
 Fixed: activate hangs on xml validation error. (GH-220).    
 Added: get filter iterator matching the task/collection runtime path in the topology.    
 
+### dds-info
+Added: --wait-for-executing-agents option to wait for the required number of agent with executing state.     
+
 ## v2.4 (2019-06-18)
 
 ### DDS common

--- a/dds-commander/src/ConnectionManager.h
+++ b/dds-commander/src/ConnectionManager.h
@@ -128,6 +128,9 @@ namespace dds
             void sendUIAgentInfo(const dds::tools_api::SAgentInfoRequestData& _info,
                                  CAgentChannel::weakConnectionPtr_t _channel);
 
+            void sendCustomCommandResponse(CAgentChannel::weakConnectionPtr_t _channel, const std::string& _json) const;
+            void sendDoneResponse(CAgentChannel::weakConnectionPtr_t _channel, tools_api::requestID_t _requestID) const;
+
           private:
             CGetLogChannelInfo m_getLog;
             CTestChannelInfo m_transportTest;

--- a/dds-tools-lib/src/ToolsProtocol.cpp
+++ b/dds-tools-lib/src/ToolsProtocol.cpp
@@ -134,14 +134,12 @@ void dds::tools_api::STopologyRequestData::_fromPT(const boost::property_tree::p
 void dds::tools_api::SCommanderInfoResponseData::_toPT(boost::property_tree::ptree& _pt) const
 {
     _pt.put<pid_t>("pid", m_pid);
-    _pt.put<uint32_t>("idleAgentsCount", m_idleAgentsCount);
     _pt.put<std::string>("activeTopologyName", m_activeTopologyName);
 }
 
 void dds::tools_api::SCommanderInfoResponseData::_fromPT(const boost::property_tree::ptree& _pt)
 {
     m_pid = _pt.get<pid_t>("pid", 0);
-    m_idleAgentsCount = _pt.get<uint32_t>("idleAgentsCount", 0);
     m_activeTopologyName = _pt.get<std::string>("activeTopologyName", std::string());
 }
 
@@ -158,6 +156,8 @@ void dds::tools_api::SCommanderInfoRequestData::_toPT(boost::property_tree::ptre
 void dds::tools_api::SAgentInfoResponseData::_toPT(boost::property_tree::ptree& _pt) const
 {
     _pt.put<uint32_t>("activeAgentsCount", m_activeAgentsCount);
+    _pt.put<uint32_t>("idleAgentsCount", m_idleAgentsCount);
+    _pt.put<uint32_t>("executingAgentsCount", m_executingAgentsCount);
     _pt.put<uint32_t>("index", m_index);
     _pt.put<string>("agentInfo", m_agentInfo);
 }
@@ -165,13 +165,17 @@ void dds::tools_api::SAgentInfoResponseData::_toPT(boost::property_tree::ptree& 
 void dds::tools_api::SAgentInfoResponseData::_fromPT(const boost::property_tree::ptree& _pt)
 {
     m_activeAgentsCount = _pt.get<uint32_t>("activeAgentsCount", 0);
+    m_idleAgentsCount = _pt.get<uint32_t>("idleAgentsCount", 0);
+    m_executingAgentsCount = _pt.get<uint32_t>("executingAgentsCount", 0);
     m_index = _pt.get<uint32_t>("index", 0);
     m_agentInfo = _pt.get<string>("agentInfo", "");
 }
 
 void dds::tools_api::SAgentInfoRequestData::_fromPT(const boost::property_tree::ptree& _pt)
 {
+    m_countersOnly = _pt.get<bool>("countersOnly", false);
 }
 void dds::tools_api::SAgentInfoRequestData::_toPT(boost::property_tree::ptree& _pt) const
 {
+    _pt.put<bool>("countersOnly", m_countersOnly);
 }

--- a/dds-tools-lib/src/ToolsProtocol.h
+++ b/dds-tools-lib/src/ToolsProtocol.h
@@ -200,7 +200,6 @@ namespace dds
         struct SCommanderInfoResponseData : SBaseResponseData<SCommanderInfoResponseData>
         {
             pid_t m_pid = 0;                  ///< PID of the commander
-            uint32_t m_idleAgentsCount = 0;   ///< The count of idle agents
             std::string m_activeTopologyName; ///< Name of active topology, empty if none is active
 
           private:
@@ -218,7 +217,7 @@ namespace dds
             bool operator==(const SCommanderInfoResponseData& _val) const
             {
                 return (SBaseData::operator==(_val) && m_pid == _val.m_pid &&
-                        m_idleAgentsCount == _val.m_idleAgentsCount);
+                        m_activeTopologyName == _val.m_activeTopologyName);
             }
         };
 
@@ -247,9 +246,11 @@ namespace dds
 
         struct SAgentInfoResponseData : SBaseResponseData<SAgentInfoResponseData>
         {
-            uint32_t m_activeAgentsCount = 0; ///< the number of online agents
-            uint32_t m_index = 0;             ///< index of the current agent
-            std::string m_agentInfo;          ///< info on the current agent
+            uint32_t m_activeAgentsCount = 0;    ///< the number of online agents
+            uint32_t m_idleAgentsCount = 0;      ///< The count of idle agents
+            uint32_t m_executingAgentsCount = 0; ///< The count of executing agents
+            uint32_t m_index = 0;                ///< index of the current agent
+            std::string m_agentInfo;             ///< info on the current agent
 
           private:
             friend SBaseData<SAgentInfoResponseData>;
@@ -266,12 +267,15 @@ namespace dds
             bool operator==(const SAgentInfoResponseData& _val) const
             {
                 return (SBaseData::operator==(_val) && m_activeAgentsCount == _val.m_activeAgentsCount &&
-                        m_index == _val.m_index && m_agentInfo == _val.m_agentInfo);
+                        m_idleAgentsCount == _val.m_idleAgentsCount &&
+                        m_executingAgentsCount == _val.m_executingAgentsCount && m_index == _val.m_index &&
+                        m_agentInfo == _val.m_agentInfo);
             }
         };
 
         struct SAgentInfoRequestData : SBaseRequestData<SAgentInfoRequestData>
         {
+            bool m_countersOnly = false; ///< Send number of active, idle and executing agents
           private:
             friend SBaseData<SAgentInfoRequestData>;
             friend SBaseRequestData<SAgentInfoRequestData>;
@@ -286,7 +290,7 @@ namespace dds
             /// \brief Equality operator.
             bool operator==(const SAgentInfoRequestData& _val) const
             {
-                return SBaseData::operator==(_val);
+                return SBaseData::operator==(_val) && m_countersOnly == _val.m_countersOnly;
             }
         };
 

--- a/dds-tools-lib/tests/Test.cpp
+++ b/dds-tools-lib/tests/Test.cpp
@@ -39,24 +39,112 @@ BOOST_AUTO_TEST_CASE(test_dds_tools_protocol)
 {
     ptree pt;
 
-    read_json("/Users/anar/DDS/2.3.30.g1de2e54/tests/test_protocol_1.json", pt);
+    read_json("test_protocol_1.json", pt);
 
     const ptree& childPT = pt.get_child("dds.tools-api");
 
     for (const auto& child : childPT)
     {
         const string& tag = child.first;
-        if (tag == "commanderInfo")
+        if (tag == "message")
         {
-            SCommanderInfoResponseData dataCommanderInfoTest;
-            dataCommanderInfoTest.m_idleAgentsCount = 105;
-            dataCommanderInfoTest.m_pid = 432;
-            dataCommanderInfoTest.m_requestID = 435;
+            SMessageResponseData testData;
+            testData.m_msg = "string";
+            testData.m_severity = dds::intercom_api::EMsgSeverity(123);
+            testData.m_requestID = 123;
 
-            SCommanderInfoResponseData dataCommanderInfo;
-            dataCommanderInfo.fromPT(child.second);
+            SMessageResponseData data;
+            data.fromPT(child.second);
 
-            BOOST_CHECK(dataCommanderInfo == dataCommanderInfoTest);
+            BOOST_CHECK(testData == data);
+        }
+        else if (tag == "done")
+        {
+            SDoneResponseData testData;
+            testData.m_requestID = 435;
+
+            SDoneResponseData data;
+            data.fromPT(child.second);
+
+            BOOST_CHECK(data == testData);
+        }
+        else if (tag == "progress")
+        {
+            SProgressResponseData testData;
+            testData.m_completed = 123;
+            testData.m_total = 123;
+            testData.m_errors = 123;
+            testData.m_time = 123;
+            testData.m_srcCommand = 123;
+
+            SProgressResponseData data;
+            data.fromPT(child.second);
+
+            BOOST_CHECK(data == testData);
+        }
+        else if (tag == "submit")
+        {
+            SSubmitRequestData testData;
+            testData.m_rms = "string";
+            testData.m_instances = 123;
+            testData.m_config = "string";
+            testData.m_pluginPath = "string";
+            testData.m_requestID = 123;
+
+            SSubmitRequestData data;
+            data.fromPT(child.second);
+
+            BOOST_CHECK(data == testData);
+        }
+        else if (tag == "topology")
+        {
+            STopologyRequestData testData;
+            testData.m_updateType = dds::tools_api::STopologyRequestData::EUpdateType(123);
+            testData.m_topologyFile = "string";
+            testData.m_disableValidation = false;
+            testData.m_requestID = 123;
+
+            STopologyRequestData data;
+            data.fromPT(child.second);
+
+            BOOST_CHECK(data == testData);
+        }
+        else if (tag == "getlog")
+        {
+            SGetLogRequestData testData;
+            testData.m_requestID = 123;
+
+            SGetLogRequestData data;
+            data.fromPT(child.second);
+
+            BOOST_CHECK(data == testData);
+        }
+        else if (tag == "agentInfo")
+        {
+            SAgentInfoResponseData testData;
+            testData.m_activeAgentsCount = 123;
+            testData.m_idleAgentsCount = 105;
+            testData.m_executingAgentsCount = 35;
+            testData.m_index = 123;
+            testData.m_agentInfo = "string";
+            testData.m_requestID = 123;
+
+            SAgentInfoResponseData data;
+            data.fromPT(child.second);
+
+            BOOST_CHECK(data == testData);
+        }
+        else if (tag == "commanderInfo")
+        {
+            SCommanderInfoResponseData testData;
+            testData.m_pid = 432;
+            testData.m_requestID = 435;
+            testData.m_activeTopologyName = "TopoName";
+
+            SCommanderInfoResponseData data;
+            data.fromPT(child.second);
+
+            BOOST_CHECK(data == testData);
         }
     }
 }
@@ -64,7 +152,6 @@ BOOST_AUTO_TEST_CASE(test_dds_tools_protocol)
 BOOST_AUTO_TEST_CASE(test_dds_tools_protocol_toJSON)
 {
     SCommanderInfoResponseData dataCommanderInfoTest;
-    dataCommanderInfoTest.m_idleAgentsCount = 105;
     dataCommanderInfoTest.m_pid = 432;
     dataCommanderInfoTest.m_requestID = 435;
 

--- a/dds-tools-lib/tests/test_protocol_1.json
+++ b/dds-tools-lib/tests/test_protocol_1.json
@@ -35,12 +35,14 @@
             "commanderInfo":
             {
                 "pid":432,
-                "idleAgentsCount": 105,
+                "activeTopologyName": "TopoName",
                 "requestID": 435
             },
             "agentInfo":
             {
                 "activeAgentsCount": 123,
+                "idleAgentsCount": 105,
+                "executingAgentsCount": 35,
                 "index": 123,
                 "agentInfo": "string",
                 "requestID": 123


### PR DESCRIPTION
- Move agent counter request data from commander info to agent info request;
- Refactor sending of custom cmds and done responses for commander;
- Update tolls API unit tests of request/response data.