### PR TITLE
dds-tools-lib: Declare ostream operators as non-friend free functions

### DIFF
--- a/dds-tools-lib/src/ToolsProtocol.h
+++ b/dds-tools-lib/src/ToolsProtocol.h
@@ -39,9 +39,9 @@ namespace dds
           public:
             /// \brief Equality operator.
             bool operator==(const SMessageResponseData& _val) const;
-            /// \brief Ostream operator.
-            friend std::ostream& operator<<(std::ostream& _os, const SMessageResponseData& _data);
         };
+        /// \brief Ostream operator.
+        std::ostream& operator<<(std::ostream& _os, const SMessageResponseData& _data);
 
         /// \brief Structure holds information of a progress response.
         struct SProgressResponseData : SBaseResponseData<SProgressResponseData>
@@ -66,9 +66,9 @@ namespace dds
           public:
             /// \brief Equality operator.
             bool operator==(const SProgressResponseData& _val) const;
-            /// \brief Ostream operator.
-            friend std::ostream& operator<<(std::ostream& _os, const SProgressResponseData& _data);
         };
+        /// \brief Ostream operator.
+        std::ostream& operator<<(std::ostream& _os, const SProgressResponseData& _data);
 
         /// \brief Structure holds information of a submit request.
         struct SSubmitRequestData : SBaseRequestData<SSubmitRequestData>
@@ -87,9 +87,9 @@ namespace dds
           public:
             /// \brief Equality operator.
             bool operator==(const SSubmitRequestData& _val) const;
-            /// \brief Ostream operator.
-            friend std::ostream& operator<<(std::ostream& _os, const SSubmitRequestData& _data);
         };
+        /// \brief Ostream operator.
+        std::ostream& operator<<(std::ostream& _os, const SSubmitRequestData& _data);
 
         /// \brief Request class of submit.
         using SSubmitRequest = SBaseRequestImpl<SSubmitRequestData, SEmptyResponseData>;
@@ -116,9 +116,9 @@ namespace dds
           public:
             /// \brief Equality operator.
             bool operator==(const STopologyRequestData& _val) const;
-            /// \brief Ostream operator.
-            friend std::ostream& operator<<(std::ostream& _os, const STopologyRequestData& _data);
         };
+        /// \brief Ostream operator.
+        std::ostream& operator<<(std::ostream& _os, const STopologyRequestData& _data);
 
         /// \brief Request class of topology.
         using STopologyRequest = SBaseRequestImpl<STopologyRequestData, SEmptyResponseData>;
@@ -145,9 +145,9 @@ namespace dds
           public:
             /// \brief Equality operator.
             bool operator==(const SCommanderInfoResponseData& _val) const;
-            /// \brief Ostream operator.
-            friend std::ostream& operator<<(std::ostream& _os, const SCommanderInfoResponseData& _data);
         };
+        /// \brief Ostream operator.
+        std::ostream& operator<<(std::ostream& _os, const SCommanderInfoResponseData& _data);
 
         /// \brief Structure holds information of a commanderInfo request.
         DDS_TOOLS_DECLARE_DATA_CLASS(SBaseRequestData, SCommanderInfoRequestData, "commanderInfo")
@@ -179,9 +179,9 @@ namespace dds
           public:
             /// \brief Equality operator.
             bool operator==(const SAgentInfoResponseData& _val) const;
-            /// \brief Ostream operator.
-            friend std::ostream& operator<<(std::ostream& _os, const SAgentInfoResponseData& _data);
         };
+        /// \brief Ostream operator.
+        std::ostream& operator<<(std::ostream& _os, const SAgentInfoResponseData& _data);
 
         /// \brief Structure holds information of agentInfo request.
         DDS_TOOLS_DECLARE_DATA_CLASS(SBaseRequestData, SAgentInfoRequestData, "agentInfo")
@@ -206,9 +206,9 @@ namespace dds
           public:
             /// \brief Equality operator.
             bool operator==(const SAgentCountResponseData& _val) const;
-            /// \brief Ostream operator.
-            friend std::ostream& operator<<(std::ostream& _os, const SAgentCountResponseData& _data);
         };
+        /// \brief Ostream operator.
+        std::ostream& operator<<(std::ostream& _os, const SAgentCountResponseData& _data);
 
         /// \brief Structure holds information of agentCount response.
         DDS_TOOLS_DECLARE_DATA_CLASS(SBaseRequestData, SAgentCountRequestData, "agentCount")


### PR DESCRIPTION
**Affects** 2.5-36-g98ca41a (current master)
**Related to** #247 

GCC `9.1.1` on Fedora 30 is still not happy about our non-inline friend-only ostream operator declarations:

```
/home/dklein/projects/DDS/dds-tools-lib/src/ToolsProtocol.cpp:55:15: warning: ‘std::ostream& dds::tools_api::operator<<(std::ostream&, const dds::tools_api::SProgressResponseData&)’ has not been declared within ‘dds::tools_api’
   55 | std::ostream& dds::tools_api::operator<<(std::ostream& _os, const SProgressResponseData& _data)
      |               ^~~
In file included from /home/dklein/projects/DDS/dds-tools-lib/src/ToolsProtocol.cpp:6:
/home/dklein/projects/DDS/dds-tools-lib/src/ToolsProtocol.h:70:34: note: only here as a ‘friend’
   70 |             friend std::ostream& operator<<(std::ostream& _os, const SProgressResponseData& _data);
      |                                  ^~~~~~~~
/home/dklein/projects/DDS/dds-tools-lib/src/ToolsProtocol.cpp:106:15: warning: ‘std::ostream& dds::tools_api::operator<<(std::ostream&, const dds::tools_api::SMessageResponseData&)’ has not been declared within ‘dds::tools_api’
  106 | std::ostream& dds::tools_api::operator<<(std::ostream& _os, const SMessageResponseData& _data)
      |               ^~~
In file included from /home/dklein/projects/DDS/dds-tools-lib/src/ToolsProtocol.cpp:6:
/home/dklein/projects/DDS/dds-tools-lib/src/ToolsProtocol.h:43:34: note: only here as a ‘friend’
   43 |             friend std::ostream& operator<<(std::ostream& _os, const SMessageResponseData& _data);
      |                                  ^~~~~~~~
/home/dklein/projects/DDS/dds-tools-lib/src/ToolsProtocol.cpp:136:15: warning: ‘std::ostream& dds::tools_api::operator<<(std::ostream&, const dds::tools_api::SSubmitRequestData&)’ has not been declared within ‘dds::tools_api’
  136 | std::ostream& dds::tools_api::operator<<(std::ostream& _os, const SSubmitRequestData& _data)
      |               ^~~
In file included from /home/dklein/projects/DDS/dds-tools-lib/src/ToolsProtocol.cpp:6:
/home/dklein/projects/DDS/dds-tools-lib/src/ToolsProtocol.h:91:34: note: only here as a ‘friend’
   91 |             friend std::ostream& operator<<(std::ostream& _os, const SSubmitRequestData& _data);
      |                                  ^~~~~~~~
/home/dklein/projects/DDS/dds-tools-lib/src/ToolsProtocol.cpp:165:15: warning: ‘std::ostream& dds::tools_api::operator<<(std::ostream&, const dds::tools_api::STopologyRequestData&)’ has not been declared within ‘dds::tools_api’
  165 | std::ostream& dds::tools_api::operator<<(std::ostream& _os, const STopologyRequestData& _data)
      |               ^~~
In file included from /home/dklein/projects/DDS/dds-tools-lib/src/ToolsProtocol.cpp:6:
/home/dklein/projects/DDS/dds-tools-lib/src/ToolsProtocol.h:120:34: note: only here as a ‘friend’
  120 |             friend std::ostream& operator<<(std::ostream& _os, const STopologyRequestData& _data);
      |                                  ^~~~~~~~
/home/dklein/projects/DDS/dds-tools-lib/src/ToolsProtocol.cpp:191:15: warning: ‘std::ostream& dds::tools_api::operator<<(std::ostream&, const dds::tools_api::SCommanderInfoResponseData&)’ has not been declared within ‘dds::tools_api’
  191 | std::ostream& dds::tools_api::operator<<(std::ostream& _os, const SCommanderInfoResponseData& _data)
      |               ^~~
In file included from /home/dklein/projects/DDS/dds-tools-lib/src/ToolsProtocol.cpp:6:
/home/dklein/projects/DDS/dds-tools-lib/src/ToolsProtocol.h:149:34: note: only here as a ‘friend’
  149 |             friend std::ostream& operator<<(std::ostream& _os, const SCommanderInfoResponseData& _data);
      |                                  ^~~~~~~~
/home/dklein/projects/DDS/dds-tools-lib/src/ToolsProtocol.cpp:236:15: warning: ‘std::ostream& dds::tools_api::operator<<(std::ostream&, const dds::tools_api::SAgentInfoResponseData&)’ has not been declared within ‘dds::tools_api’
  236 | std::ostream& dds::tools_api::operator<<(std::ostream& _os, const SAgentInfoResponseData& _data)
      |               ^~~
In file included from /home/dklein/projects/DDS/dds-tools-lib/src/ToolsProtocol.cpp:6:
/home/dklein/projects/DDS/dds-tools-lib/src/ToolsProtocol.h:183:34: note: only here as a ‘friend’
  183 |             friend std::ostream& operator<<(std::ostream& _os, const SAgentInfoResponseData& _data);
      |                                  ^~~~~~~~
/home/dklein/projects/DDS/dds-tools-lib/src/ToolsProtocol.cpp:268:15: warning: ‘std::ostream& dds::tools_api::operator<<(std::ostream&, const dds::tools_api::SAgentCountResponseData&)’ has not been declared within ‘dds::tools_api’
  268 | std::ostream& dds::tools_api::operator<<(std::ostream& _os, const SAgentCountResponseData& _data)
      |               ^~~
In file included from /home/dklein/projects/DDS/dds-tools-lib/src/ToolsProtocol.cpp:6:
/home/dklein/projects/DDS/dds-tools-lib/src/ToolsProtocol.h:210:34: note: only here as a ‘friend’
  210 |             friend std::ostream& operator<<(std::ostream& _os, const SAgentCountResponseData& _data);
      |                                  ^~~~~~~~
```

Declaring them as normal free functions as proposed in this PR silences the warning for me.