### PR TITLE
Fixed topology update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,13 @@ set(MiscCommon_LOCATION
 	${MiscCommon_LOCATION}/dds_ncf/src
 )
 #
+# Custom compiler definitions
+#
+# If process is killed or crased it can leave opened and locked interprocess mutex. It leads to hanging boost::interprocess::message_queue::timed_send function. The function tries to write to the queue which is locked by the mutex from the killed process. BOOST implements a workaround flag - BOOST_INTERPROCESS_ENABLE_TIMEOUT_WHEN_LOCKING. It forces the boost::interprocess to use timed mutexes instead of a simple ones.
+add_compile_definitions(BOOST_INTERPROCESS_ENABLE_TIMEOUT_WHEN_LOCKING)
+# boost::interprocess mutexes timeout duration.
+add_compile_definitions(BOOST_INTERPROCESS_TIMEOUT_WHEN_LOCKING_DURATION_MS=5000)
+#
 # additional compiler and linker flags for C++11
 #
 if(APPLE)

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -5,6 +5,7 @@
 ### DDS common
 Added: Users now can specify custom environment scripts for each task. (GH-24)    
 Modified: Improved cleaning of child processes of user tasks.     
+Fixed: If process is killed or crased it can leave opened and locked interprocess mutex. It leads to hanging boost::interprocess::message_queue::timed_send function. The function tries to write to the queue which is locked by the mutex from the killed process. BOOST implements a workaround flag - BOOST_INTERPROCESS_ENABLE_TIMEOUT_WHEN_LOCKING. It forces the boost::interprocess to use timed mutexes instead of a simple ones.    
 
 ### dds-agent
 Modified: Intercom channel got a dedicated service. Now DDS main transport and Intercom work on different threads. (GH-279)    

--- a/dds-protocol-lib/src/BaseChannelImpl.h
+++ b/dds-protocol-lib/src/BaseChannelImpl.h
@@ -150,15 +150,15 @@ namespace dds
         break;                                                                                                      \
     }
 
-#define END_MSG_MAP()                                                                                         \
-    default:                                                                                                  \
-        LOG(MiscCommon::error) << "The received message doesn't have a handler: " << _currentMsg->toString(); \
-        }                                                                                                     \
-        }                                                                                                     \
-        catch (std::exception & _e)                                                                           \
-        {                                                                                                     \
-            LOG(MiscCommon::error) << "Channel processMessage: " << _e.what();                                \
-        }                                                                                                     \
+#define END_MSG_MAP()                                                                                              \
+    default:                                                                                                       \
+        LOG(MiscCommon::error) << "The received message doesn't have a handler: " << _currentMsg->toString();      \
+        }                                                                                                          \
+        }                                                                                                          \
+        catch (std::exception & _e)                                                                                \
+        {                                                                                                          \
+            LOG(MiscCommon::error) << "Channel processMessage (" << _currentMsg->toString() << "): " << _e.what(); \
+        }                                                                                                          \
         }
 
 // Raw message processing


### PR DESCRIPTION
- Use BOOST BOOST_INTERPROCESS_ENABLE_TIMEOUT_WHEN_LOCKING flag. It forces the boost::interprocess to use timed mutexes instead of a simple ones. This fixes the issue if process is killed or crased and leaves opened and locked interprocess mutex.
- Fix topology update logic: first stop the tasks and than update the topology on agents.
- SM channel: seperate mutexes for input and output containers of message_queue.
- Fix agent replies during topology update