### PR TITLE
CMake improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ set(DDS_PROTOCOL_VERSION "2")
 # Check if cmake has the required version
 #
 cmake_minimum_required( VERSION 3.11.0 FATAL_ERROR )
+cmake_policy(VERSION 3.11...3.16)
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -404,11 +404,6 @@ set( WN_PKG_DIR "${CMAKE_BINARY_DIR}/dds-wrk-bin" )
 set( WN_PKG_NAME_ARCH "${WN_PKG_NAME}.tar.gz" )
 set( WN_PKG_REMOTE_DIR "/u/ddswww/web-docs/releases/add/${DDS_VERSION}" )
 
-set(DDS_BOOST_LIB_DIR ${Boost_LIBRARY_DIR})
-if("${DDS_BOOST_LIB_DIR}" STREQUAL "")
-	set(DDS_BOOST_LIB_DIR ${Boost_LIBRARY_DIR_RELEASE})
-endif()
-
 if(ENV{DDS_LD_LIBRARY_PATH})
   # because of SIP on macOS we can't use (DY)LD_LIBRARY_PATH.
   # But we need to search also in custom location for libstdc++ in case if user installs a custom version of gcc/clang.
@@ -418,7 +413,7 @@ else()
   file(TO_CMAKE_PATH "$ENV{LD_LIBRARY_PATH}" ENV_LD_LIBRARY_PATH)
 endif()
 
-set(PREREQ_DIRS "$<TARGET_FILE_DIR:dds-user-defaults>::$<TARGET_FILE_DIR:dds_protocol_lib>::$<TARGET_FILE_DIR:dds_intercom_lib>::$<TARGET_FILE_DIR:dds_topology_lib>::$<TARGET_FILE_DIR:dds_ncf>::${DDS_BOOST_LIB_DIR}")
+set(PREREQ_DIRS "$<TARGET_FILE_DIR:dds-user-defaults>::$<TARGET_FILE_DIR:dds_protocol_lib>::$<TARGET_FILE_DIR:dds_intercom_lib>::$<TARGET_FILE_DIR:dds_topology_lib>::$<TARGET_FILE_DIR:dds_ncf>::$<TARGET_FILE_DIR:Boost::log>")
 foreach(p IN LISTS ENV_LD_LIBRARY_PATH)
   set(PREREQ_DIRS "${PREREQ_DIRS}::${p}")
 endforeach()
@@ -466,7 +461,7 @@ add_custom_target( wn_bin
 	COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:dds-agent> "${WN_PKG_DIR}"
 	COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:dds-user-defaults> "${WN_PKG_DIR}"
 	COMMAND ${CMAKE_COMMAND} -DPREREQ_DESTINATION=${WN_PKG_DIR} -DDDS_AGENT_BIN_PATH=${DDS_AGENT_BIN_PATH}
-		-DPREREQ_DIRS=${PREREQ_DIRS} -DDDS_BOOST_LIB_DIR=${DDS_BOOST_LIB_DIR} -P "${CMAKE_SOURCE_DIR}/cmake/modules/DDS_CollectPrerequisites.cmake"
+		-DPREREQ_DIRS=${PREREQ_DIRS} -P "${CMAKE_SOURCE_DIR}/cmake/modules/DDS_CollectPrerequisites.cmake"
 	COMMAND ${CMAKE_COMMAND} -E tar czf ${WN_PKG_NAME_ARCH} "${WN_PKG_DIR}"
 	COMMAND chmod go+xr ${WN_PKG_NAME_ARCH}
 	COMMENT "Generate WN binary package"

--- a/cmake/modules/DDS_CollectPrerequisites.cmake
+++ b/cmake/modules/DDS_CollectPrerequisites.cmake
@@ -5,14 +5,13 @@ include(GetPrerequisites)
 
 # WORKAROUND: if "macro" is used it doesn't outoup "message" messages.
 #macro(DDS_CollectPrerequisites)
-	
+
 	###################################################
 	## Collect prerequisites for WN PKG
 	###################################################
-	message( STATUS "Using BOOST Library dir: " ${DDS_BOOST_LIB_DIR})
 	string(REPLACE "::" ";" PREREQ_DIRS_LIST ${PREREQ_DIRS})
 	message( STATUS "prerequisite dirs: " "${PREREQ_DIRS_LIST}")
-	
+
 	# WORKAROUND: the list comes broken into the macro, we need to rebuild it
 	# if we don't do that, the  get_prerequisites doesn't use all avaliable directories.
 	# I didn't find anyother way, but rebuilt the list.
@@ -24,7 +23,7 @@ include(GetPrerequisites)
 
 	get_prerequisites(${DDS_AGENT_BIN_PATH} DEPENDENCIES 1 1 "" "${PREREQ_DIRS_LIST_REBUILT}")
 
-	
+
 	foreach(DEPENDENCY_FILE ${DEPENDENCIES})
 		# get file name to be able to resolve files with @rpath on macOS
 		get_filename_component(PREREQNAME "${DEPENDENCY_FILE}"  NAME)

--- a/cmake/modules/DDS_CollectPrerequisitesGen.cmake.in
+++ b/cmake/modules/DDS_CollectPrerequisitesGen.cmake.in
@@ -5,14 +5,13 @@ include(GetPrerequisites)
 
 # WORKAROUND: if "macro" is used it doesn't outoup "message" messages.
 #macro(DDS_CollectPrerequisites)
-	
+
 	###################################################
 	## Collect prerequisites for WN PKG
 	###################################################
-	message( STATUS "Using BOOST Library dir: " @DDS_BOOST_LIB_DIR@)
 	string(REPLACE "::" ";" PREREQ_DIRS_LIST @PREREQ_DIRS@)
 	message( STATUS "prerequisite dirs: " "${PREREQ_DIRS_LIST}")
-	
+
 	# WORKAROUND: the list comes broken into the macro, we need to rebuild it
 	# if we don't do that, the  get_prerequisites doesn't use all avaliable directories.
 	# I didn't find anyother way, but rebuilt the list.
@@ -24,7 +23,7 @@ include(GetPrerequisites)
 
 	get_prerequisites(@DDS_PREREQ_SOURCE_BIN_PATH@ DEPENDENCIES 1 1 "" "${PREREQ_DIRS_LIST_REBUILT}")
 
-	
+
 	foreach(DEPENDENCY_FILE ${DEPENDENCIES})
 		# get file name to be able to resolve files with @rpath on macOS
 		get_filename_component(PREREQNAME "${DEPENDENCY_FILE}"  NAME)


### PR DESCRIPTION
*First commit*: CMake already opts-in to all policies up to the minimum required CMake version by default. The additional [cmake_policy](https://cmake.org/cmake/help/latest/command/cmake_policy.html) call tells newer cmake versions to enable newer policies too, if available. *Motivation*: I was already used to [CMP0074](https://cmake.org/cmake/help/latest/policy/CMP0074.html) which was not yet enabled for DDS.

*Second commit*: The issue with occasionally empty `${Boost_LIBRARY_DIR*}` variable we have discovered just recently when testing many different cmake and boost version together during the spack packaging efforts of DDS. I believe the issue can happen with CMake < `3.15` and Boost >= `1.70` and `Boost_NO_BOOST_CMAKE=OFF`. *Motivation*: We are applying this patch now on the spack package level, but it would be awesome, if you could include it upstream in some form, so we can eventually drop it from the spack package. (CC: @ChristianTackeGSI)