### PR TITLE
Fix execute()

### DIFF
--- a/MiscCommon/Process.h
+++ b/MiscCommon/Process.h
@@ -524,9 +524,7 @@ namespace MiscCommon
 
             boost::asio::deadline_timer watchdog{ ios, boost::posix_time::seconds(_Timeout.count()) };
 
-            bp::group g;
             bp::child c(smartCmd,
-                        g,
                         bp::std_in.close(),
                         bp::std_out > outPipe,
                         bp::std_err > errPipe,
@@ -555,7 +553,7 @@ namespace MiscCommon
                     errPipe.close();
                     ios.stop();
                     // Child didn't yet finish. Terminating it...
-                    g.terminate();
+                    c.terminate();
                 }
             });
 

--- a/MiscCommon/tests/Test_SysHelper.cpp
+++ b/MiscCommon/tests/Test_SysHelper.cpp
@@ -20,7 +20,7 @@ using namespace MiscCommon;
 using namespace std;
 
 //=============================================================================
-BOOST_AUTO_TEST_SUITE(pod_agent_ProtocolCommands);
+BOOST_AUTO_TEST_SUITE(test_SysHelper);
 //=============================================================================
 BOOST_AUTO_TEST_CASE(test_MiscCommon_smart_path0)
 {


### PR DESCRIPTION
- Do not create process group in execute(). The reason is that dds-daemonize uses ::setsid.
- Create unit test for execute() and dds-daemonize