### PR TITLE
Fix compile on older compilers

### DIFF
--- a/dds-submit/src/Options.h
+++ b/dds-submit/src/Options.h
@@ -45,7 +45,7 @@ namespace dds
             size_t m_number{ 0 };
             size_t m_slots{ 0 };
             bool m_bListPlugins{ false };
-            boost::uuids::uuid m_sid{ boost::uuids::nil_uuid() };
+            boost::uuids::uuid m_sid = boost::uuids::nil_uuid();
         } SOptions_t;
         //=============================================================================
         inline std::ostream& operator<<(std::ostream& _stream, const SOptions& val)


### PR DESCRIPTION
Some older compilers (gcc 4.9-5.1) do not like brace initialization.
This fixes the compile for us.
Can you please check, if this change is okay for you?

Thanks go to @dennisklein for helping.