### PR TITLE
dds-topology: new getRuntimeTask and getRuntimeCollection methods

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,6 +4,7 @@
 
 ### dds-topology
 Added: new std::istream based APIs.    
+Added: new CTopology::getRuntimeTask and CTopology::getRuntimeCollection methods which take either ID or runtime path as input.    
 
 
 ## v3.4 (2020-07-01)

--- a/dds-topology-lib/src/TopoCore.cpp
+++ b/dds-topology-lib/src/TopoCore.cpp
@@ -15,6 +15,7 @@
 #include "CRC.h"
 // BOOST
 #include <boost/filesystem.hpp>
+#include <boost/lexical_cast.hpp>
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/algorithm/copy.hpp>
 #include <boost/regex.hpp>
@@ -244,6 +245,38 @@ const STopoRuntimeCollection& CTopoCore::getRuntimeCollectionByIdPath(const std:
     if (it == m_collectionIdPathToIdMap.end())
         throw runtime_error("Can not find collection with path ID " + _idPath);
     return getRuntimeCollectionById(it->second);
+}
+
+const STopoRuntimeTask& CTopoCore::getRuntimeTask(const std::string& _path) const
+{
+    try
+    {
+        // throws boost::bad_lexical_cast if path is not a number
+        uint64_t taskID{ boost::lexical_cast<uint64_t>(_path) };
+        // throws std::runtime_error if ID not found
+        return getRuntimeTaskById(taskID);
+    }
+    catch (boost::bad_lexical_cast&)
+    {
+        // throws std::runtime_error if path not found
+        return getRuntimeTaskByIdPath(_path);
+    }
+}
+
+const STopoRuntimeCollection& CTopoCore::getRuntimeCollection(const std::string& _path) const
+{
+    try
+    {
+        // throws boost::bad_lexical_cast if path is not a number
+        uint64_t taskID{ boost::lexical_cast<uint64_t>(_path) };
+        // throws std::runtime_error if ID not found
+        return getRuntimeCollectionById(taskID);
+    }
+    catch (boost::bad_lexical_cast&)
+    {
+        // throws std::runtime_error if path not found
+        return getRuntimeCollectionByIdPath(_path);
+    }
 }
 
 STopoRuntimeTask::FilterIteratorPair_t CTopoCore::getRuntimeTaskIterator(const STopoRuntimeTask::Map_t& _map,

--- a/dds-topology-lib/src/TopoCore.h
+++ b/dds-topology-lib/src/TopoCore.h
@@ -74,10 +74,18 @@ namespace dds
             std::string getFilepath() const;
             uint32_t getHash() const;
             CTopoGroup::Ptr_t getMainGroup() const;
+            /// \brief Returns runtime task by ID.
             const STopoRuntimeTask& getRuntimeTaskById(Id_t _id) const;
+            /// \brief Returns runtime collection by ID.
             const STopoRuntimeCollection& getRuntimeCollectionById(Id_t _id) const;
+            /// \brief Returns runtime task by runtime path.
             const STopoRuntimeTask& getRuntimeTaskByIdPath(const std::string& _idPath) const;
+            /// \brief Returns runtime collection by runtime path.
             const STopoRuntimeCollection& getRuntimeCollectionByIdPath(const std::string& _idPath) const;
+            /// \brief Returns runtime task by either ID or runtime path.
+            const STopoRuntimeTask& getRuntimeTask(const std::string& _path) const;
+            /// \brief Returns runtime collection by either ID or runtime path.
+            const STopoRuntimeCollection& getRuntimeCollection(const std::string& _path) const;
             std::pair<size_t, size_t> getRequiredNofAgents(size_t _defaultNumSlots) const;
             size_t getTotalNofTasks() const;
 

--- a/dds-topology-lib/src/Topology.cpp
+++ b/dds-topology-lib/src/Topology.cpp
@@ -73,6 +73,16 @@ const STopoRuntimeCollection& CTopology::getRuntimeCollectionByIdPath(const stri
     return m_topo->getRuntimeCollectionByIdPath(_idPath);
 }
 
+const STopoRuntimeTask& CTopology::getRuntimeTask(const std::string& _path) const
+{
+    return m_topo->getRuntimeTask(_path);
+}
+
+const STopoRuntimeCollection& CTopology::getRuntimeCollection(const std::string& _path) const
+{
+    return m_topo->getRuntimeCollection(_path);
+}
+
 STopoRuntimeTask::FilterIteratorPair_t CTopology::getRuntimeTaskIterator(STopoRuntimeTask::Condition_t _condition) const
 {
     return m_topo->getRuntimeTaskIterator(_condition);

--- a/dds-topology-lib/src/Topology.h
+++ b/dds-topology-lib/src/Topology.h
@@ -70,6 +70,14 @@ namespace dds
             /// \param[in] _idPath Runtime collection path in the topology.
             const STopoRuntimeCollection& getRuntimeCollectionByIdPath(const std::string& _idPath) const;
 
+            /// \brief Returns runtime task by either ID or runtime path.
+            /// \param[in] _path Either ID or runtime path.
+            const STopoRuntimeTask& getRuntimeTask(const std::string& _path) const;
+
+            /// \brief Returns runtime collection by either ID or runtime path.
+            /// \param[in] _path Either ID or runtime path.
+            const STopoRuntimeCollection& getRuntimeCollection(const std::string& _path) const;
+
             /// \brief Returns runtime task filter iterator.
             /// \param[in] _condition If provided than iterate over tasks passed the condition.
             STopoRuntimeTask::FilterIteratorPair_t getRuntimeTaskIterator(

--- a/dds-topology-lib/tests/Test.cpp
+++ b/dds-topology-lib/tests/Test.cpp
@@ -188,6 +188,78 @@ BOOST_AUTO_TEST_CASE(test_dds_topology_iterators)
 }
 
 template <class T>
+void test_topology_runtime(T& _input)
+{
+    CTopoCore topology;
+    topology.init(_input);
+
+    //
+    // Tasks
+    //
+
+    // Check existing paths
+    for (const auto& v : topology.getTaskIdPathToIdMap())
+    {
+        string path{ v.first };
+        Id_t id{ v.second };
+
+        auto task1{ topology.getRuntimeTask(path) };
+        auto task2{ topology.getRuntimeTask(to_string(id)) };
+        auto task3{ topology.getRuntimeTaskById(id) };
+        auto task4{ topology.getRuntimeTaskByIdPath(path) };
+
+        BOOST_CHECK(task1.m_taskPath == path);
+        BOOST_CHECK(task2.m_taskPath == path);
+        BOOST_CHECK(task3.m_taskPath == path);
+        BOOST_CHECK(task4.m_taskPath == path);
+    }
+
+    // Check non existing paths
+    BOOST_CHECK_THROW(topology.getRuntimeTask("main/wrong_0/task_0/path_1"), runtime_error);
+    BOOST_CHECK_THROW(topology.getRuntimeTask("123456"), runtime_error);
+    BOOST_CHECK_THROW(topology.getRuntimeTaskById(123456), runtime_error);
+    BOOST_CHECK_THROW(topology.getRuntimeTaskByIdPath("main/wrong_0/task_0/path_1"), runtime_error);
+
+    //
+    // Collections
+    //
+
+    // Check existing paths
+    for (const auto& v : topology.getCollectionIdPathToIdMap())
+    {
+        string path{ v.first };
+        Id_t id{ v.second };
+
+        auto c1{ topology.getRuntimeCollection(path) };
+        auto c2{ topology.getRuntimeCollection(to_string(id)) };
+        auto c3{ topology.getRuntimeCollectionById(id) };
+        auto c4{ topology.getRuntimeCollectionByIdPath(path) };
+
+        BOOST_CHECK(c1.m_collectionPath == path);
+        BOOST_CHECK(c2.m_collectionPath == path);
+        BOOST_CHECK(c3.m_collectionPath == path);
+        BOOST_CHECK(c4.m_collectionPath == path);
+    }
+
+    // Check non existing paths
+    BOOST_CHECK_THROW(topology.getRuntimeCollection("main/wrong_0/collection_0/path_1"), runtime_error);
+    BOOST_CHECK_THROW(topology.getRuntimeCollection("123456"), runtime_error);
+    BOOST_CHECK_THROW(topology.getRuntimeCollectionById(123456), runtime_error);
+    BOOST_CHECK_THROW(topology.getRuntimeCollectionByIdPath("main/wrong_0/collection_0/path_1"), runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(test_dds_topology_runtime)
+{
+    // Test file input
+    string topoFile("topology_test_1.xml");
+    test_topology_runtime(topoFile);
+
+    // Test stream input
+    ifstream topoStream(topoFile);
+    test_topology_runtime(topoStream);
+}
+
+template <class T>
 void test_topology_parser_xml(const string& _filename)
 {
     T input(_filename);


### PR DESCRIPTION
New methods take as input either ID or a runtime path.