### PR TITLE
Fixed a case when topology object goes out of scope

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,9 +4,11 @@
 
 ### DDS common
 Removed: obsolete test project. ODC is used as an integration platform for DDS.    
+Fixed: in some edge cases a topology update, performed during an intensive key-value exchange, can lead to a segmentaion fault.    
 
 ### dds-tools-api
 Added: CSession::userDefaultsGetValueForKey - returns a configuration value for a given configuration key.   
+
 ### dds-topology
 Added: new std::istream based APIs.    
 Added: new CTopology::getRuntimeTask and CTopology::getRuntimeCollection methods which take either ID or runtime path as input.    

--- a/dds-agent/src/CommanderChannel.h
+++ b/dds-agent/src/CommanderChannel.h
@@ -141,7 +141,7 @@ namespace dds
             uint16_t m_connectionAttempts{ 1 };
             std::mutex m_taskIDToSlotIDMapMutex;
             std::map<uint64_t, uint64_t> m_taskIDToSlotIDMap;
-            topology_api::CTopoCore m_topo;
+            topology_api::CTopoCore::Ptr_t m_topo{ std::make_shared<topology_api::CTopoCore>() };
             std::mutex m_topoMutex;
 
             CSMIntercomChannel::connectionPtr_t m_intercomChannel;

--- a/dds-topology-lib/src/TopoCore.h
+++ b/dds-topology-lib/src/TopoCore.h
@@ -32,6 +32,9 @@ namespace dds
             /// Task/Collection ID path  to Task/Collection ID map
             using IdPathToIdMap_t = std::map<std::string, Id_t>;
 
+            /// std::shared_ptr
+            using Ptr_t = std::shared_ptr<CTopoCore>;
+
           public:
             /// \brief Constructor.
             CTopoCore();


### PR DESCRIPTION
- in some edge cases a topology update, performed during an intensive key-value exchange, can lead to a segmentaion fault.