### PR TITLE
dds-session: fix start behaviour

### DIFF
--- a/dds-session/src/main.cpp
+++ b/dds-session/src/main.cpp
@@ -125,13 +125,20 @@ int main(int argc, char* argv[])
             CStart start;
             start.start(options.m_bMixed);
 
-            vector<fs::path> session_dirs;
-            StringVector_t sessions;
-            rebuildSessions(session_dirs, sessions);
-            setDefaultSession(sessions, start.getSessionID());
-            LOG(log_stdout_clean) << "Default DDS session is set to " << start.getSessionID();
-            LOG(log_stdout_clean) << "Currently running DDS sessions:";
-            listSessions(session_dirs, SSessionsSorting::sort_running);
+            try
+            {
+                vector<fs::path> session_dirs;
+                StringVector_t sessions;
+                rebuildSessions(session_dirs, sessions);
+                setDefaultSession(sessions, start.getSessionID());
+                LOG(log_stdout_clean) << "Default DDS session is set to " << start.getSessionID();
+                LOG(log_stdout_clean) << "Currently running DDS sessions:";
+                listSessions(session_dirs, SSessionsSorting::sort_running);
+            }
+            catch (exception& e)
+            {
+                LOG(warning) << "Failed to perform checks after commander started: " << e.what();
+            }
 
             return EXIT_SUCCESS;
         }

--- a/dds-tools-lib/tests/TestSession.cpp
+++ b/dds-tools-lib/tests/TestSession.cpp
@@ -30,7 +30,7 @@ void createDDS(CSession& _session)
     boost::uuids::uuid sid;
     BOOST_CHECK_NO_THROW(sid = _session.create());
     BOOST_CHECK(!sid.is_nil());
-    BOOST_CHECK(CSession::getDefaultSessionID() == sid);
+    // BOOST_CHECK(CSession::getDefaultSessionID() == sid);
     BOOST_CHECK(_session.IsRunning());
     BOOST_CHECK_THROW(_session.create(), runtime_error);
     BOOST_CHECK_THROW(_session.attach(sid), runtime_error);


### PR DESCRIPTION
- if some of the action failed after DDS commander was successfully started, do not exit with error.
- do not compare default session ID with the newly created session ID. It can fail in case of a parallel test execution.