### PR TITLE
Fix queue drain for intercom channel

### DIFF
--- a/dds-agent/src/CommanderChannel.cpp
+++ b/dds-agent/src/CommanderChannel.cpp
@@ -471,6 +471,9 @@ bool CCommanderChannel::on_cmdASSIGN_USER_TASK(SCommandAttachmentImpl<cmdASSIGN_
         return true;
     }
 
+    // Revoke drain of the write queue to start accept messages
+    m_intercomChannel->drainWriteQueue(false, slot->m_id);
+
     pushMsg<cmdREPLY>(SReplyCmd("User task assigned", (uint16_t)SReplyCmd::EStatusCode::OK, 0, cmdASSIGN_USER_TASK),
                       _sender.m_ID);
 
@@ -495,9 +498,6 @@ bool CCommanderChannel::on_cmdACTIVATE_USER_TASK(SCommandAttachmentImpl<cmdACTIV
     }
 
     const SSlotInfo& slot = slot_it->second;
-
-    // Revoke drain of the write queue to start accept messages
-    m_intercomChannel->drainWriteQueue(false, slot.m_id);
 
     string sUsrExe(slot.m_sUsrExe);
 

--- a/dds-tools-lib/tests/TestSession.cpp
+++ b/dds-tools-lib/tests/TestSession.cpp
@@ -193,9 +193,7 @@ void makeRequests(CSession& _session,
     const fs::path logDir{ dds::user_defaults_api::CUserDefaults::instance().getAgentLogStorageDir() };
     const string stringToCount{ "Task successfully done" };
     const size_t count{ countStringsInDir(logDir, stringToCount) };
-
-    // TODO: FIXME: This check fails sometime because some tasks failed to gett all the keys. Needs investigation
-    // BOOST_CHECK_EQUAL(count, requiredCount);
+    BOOST_CHECK_EQUAL(count, requiredCount);
 
     // Remove DDS logs after parsing
     fs::remove_all(logDir);


### PR DESCRIPTION
- Disable queque drain during task assignment instead of task activation.
- Enable checks in unit tests that task finisherd successfully.