### PR TITLE
Start to add codemeta.json

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -1,0 +1,26 @@
+{
+    "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
+    "@type": "SoftwareSourceCode",
+    "name": "FairRootGroup/DDS",
+    "description": "<p>The Dynamic Deployment System (DDS) - is a tool-set that automates and significantly simplifies a deployment of user defined processes and their dependencies on any resource management system using a given topology.</p>",
+    "license": "https://spdx.org/licenses/CC-BY-4.0",
+    "version": "3.2",
+    "datePublished": "2020-05-26",
+    "contributor": [
+        {
+            "@type": "Person",
+            "familyName": "Manafov",
+            "givenName": "Anar"
+        },
+        {
+            "@type": "Person",
+            "familyName": "Lebedev",
+            "givenName": "Andrey"
+        },
+        {
+            "@type": "Person",
+            "familyName": "Al-Turany",
+            "givenName": "Mohammad"
+        }
+    ]
+}


### PR DESCRIPTION
codemeta.json is becoming a standard format for describing software. Let's start to add it.

This is also starting to get relevant in the context of ESCAPE.

I created the current codemeta.json to match the entry on zenodo as closely as possible. That means, that any issues with the zenodo entry are also issues with the codemeta data.

Notes:
* zenodo lists the license as CC-BY-4.0 (also reflected into the codemeta.json file)
  github lists it as LGPL-3.0 (either "only" or "and-later", not checked that details)

Helpful:
* There is a codemeta generator/viewer: https://codemeta.github.io/codemeta-generator/
  You can even paste the suggested codemeta.json there and view it.