### PR TITLE
GH-399: Tools API: shutdown agents

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -24,9 +24,10 @@ Added: DDS agent monitors available disk space and if the (configurable) thresho
 
 ### dds-tools-api
 Added: CSession::userDefaultsGetValueForKey - returns a configuration value for a given configuration key.    
-Added: new `SSlotInfoRequest` returning a list of details of all active slots (GH-374).    
+Added: a new `SSlotInfoRequest` request returns a list of all active slots details. (GH-374)    
 Added: task path to `OnTaskDone` reply.    
 Added: `Topology` request returns extended info of each activated or stopped task via new `STopologyResponseData` data class.    
+Added: A new `SAgentCommandRequest` request to shutdown agents by ID or by slotID. (GH-399)   
 
 ### dds-topology
 Added: new std::istream based APIs.    

--- a/dds-commander/src/AgentChannel.cpp
+++ b/dds-commander/src/AgentChannel.cpp
@@ -118,7 +118,7 @@ bool CAgentChannel::on_cmdREPLY_HOST_INFO(SCommandAttachmentImpl<cmdREPLY_HOST_I
 
     // Request agent to add Task Slots
     // We get the number of slots from the agent. On submit each agent is assiugned to a fixed number of slots. Then
-    // when agent is up, we requast tyhe agent to actul,ly active each slot.
+    // when agent is up, we requast tyhe agent to actully active each slot.
     LOG(info) << "Requesting " << _attachment->m_slots << " task slots from " << m_info.m_id;
     for (size_t i = 0; i < _attachment->m_slots; ++i)
     {

--- a/dds-commander/src/ConnectionManager.h
+++ b/dds-commander/src/ConnectionManager.h
@@ -124,6 +124,8 @@ namespace dds
 
             void sendCustomCommandResponse(CAgentChannel::weakConnectionPtr_t _channel, const std::string& _json) const;
             void sendDoneResponse(CAgentChannel::weakConnectionPtr_t _channel, tools_api::requestID_t _requestID) const;
+            void executeAgentCommand(const dds::tools_api::SAgentCommandRequestData& _info,
+                                     CAgentChannel::weakConnectionPtr_t _channel);
 
           private:
             CGetLogChannelInfo m_getLog;

--- a/dds-tools-lib/src/Tools.cpp
+++ b/dds-tools-lib/src/Tools.cpp
@@ -359,6 +359,10 @@ void CSession::notify(std::istream& _stream)
                     [&child](SOnTaskDoneRequest::ptr_t _request)
                     { _request->execResponseCallback(SOnTaskDoneResponseData(child.second)); });
             }
+            else if (it->second.type() == typeid(SAgentCommandRequest::ptr_t))
+            {
+                processRequest<SAgentCommandRequest>(it->second, child, nullptr);
+            }
         }
     }
     catch (exception& error)
@@ -428,6 +432,7 @@ template void CSession::sendRequest<SAgentInfoRequest>(SAgentInfoRequest::ptr_t)
 template void CSession::sendRequest<SSlotInfoRequest>(SSlotInfoRequest::ptr_t);
 template void CSession::sendRequest<SAgentCountRequest>(SAgentCountRequest::ptr_t);
 template void CSession::sendRequest<SOnTaskDoneRequest>(SOnTaskDoneRequest::ptr_t);
+template void CSession::sendRequest<SAgentCommandRequest>(SAgentCommandRequest::ptr_t);
 
 template <class Request_t>
 void CSession::syncSendRequest(const typename Request_t::request_t& _requestData,
@@ -447,6 +452,9 @@ template void CSession::syncSendRequest<STopologyRequest>(const STopologyRequest
 template void CSession::syncSendRequest<SGetLogRequest>(const SGetLogRequest::request_t&,
                                                         const std::chrono::seconds&,
                                                         ostream*);
+template void CSession::syncSendRequest<SAgentCommandRequest>(const SAgentCommandRequest::request_t&,
+                                                              const std::chrono::seconds&,
+                                                              ostream*);
 
 template <class Request_t>
 void CSession::syncSendRequest(const typename Request_t::request_t& _requestData,

--- a/dds-tools-lib/src/Tools.h
+++ b/dds-tools-lib/src/Tools.h
@@ -174,6 +174,18 @@ namespace dds
          * \endcode
          *
          *
+         * \par Example5: Request Agent shutdown by AgentID with a sync request
+         * \code
+         *  ...
+         * // create a session
+         * SAgentCommandRequest::request_t agentCmd;
+         * agentCmd.m_commandType = SAgentCommandRequestData::EAgentCommandType::shutDownByID;
+         * agentCmd.m_arg1 = <Given AgentID>;
+         * session.syncSendRequest<SAgentCommandRequest>(agentCmd, kTimeout, &std::cout);
+         *  ...
+         * \endcode
+         *
+         *
          */
         class CSession
         {

--- a/dds-tools-lib/src/ToolsProtocol.cpp
+++ b/dds-tools-lib/src/ToolsProtocol.cpp
@@ -623,3 +623,54 @@ namespace dds
         }
     } // namespace tools_api
 } // namespace dds
+
+///////////////////////////////////
+// SAgentCommandRequestData
+///////////////////////////////////
+
+// this declaration is important to help older compilers to eat this static constexpr
+constexpr const char* SAgentCommandRequestData::_protocolTag;
+
+SAgentCommandRequestData::SAgentCommandRequestData()
+{
+}
+
+SAgentCommandRequestData::SAgentCommandRequestData(const boost::property_tree::ptree& _pt)
+{
+    fromPT(_pt);
+}
+
+void SAgentCommandRequestData::_toPT(boost::property_tree::ptree& _pt) const
+{
+    _pt.put<uint8_t>("commandType", static_cast<uint8_t>(m_commandType));
+    _pt.put<uint64_t>("arg1", m_arg1);
+    _pt.put<string>("arg2", m_arg2);
+}
+
+void SAgentCommandRequestData::_fromPT(const boost::property_tree::ptree& _pt)
+{
+    m_commandType = static_cast<EAgentCommandType>(_pt.get<uint8_t>("commandType", 0));
+    m_arg1 = _pt.get<uint64_t>("arg1", 0);
+    m_arg2 = _pt.get<string>("arg2", string());
+}
+
+bool SAgentCommandRequestData::operator==(const SAgentCommandRequestData& _val) const
+{
+    return (SBaseData::operator==(_val) && m_commandType == _val.m_commandType && m_arg1 == _val.m_arg1 &&
+            m_arg2 == _val.m_arg2);
+}
+
+// We need to put function implementation in the same "dds::tools_api" namespace as a friend function declaration.
+// Such declaration "std::ostream& dds::tools_api::operator<<(std::ostream& _os, const ***& _data)" doesn't help.
+// In order to silent GCC warning "*** has not been declared within 'dds::tools_api'"
+namespace dds
+{
+    namespace tools_api
+    {
+        std::ostream& operator<<(std::ostream& _os, const SAgentCommandRequestData& _data)
+        {
+            return _os << _data.defaultToString() << "; commandType: " << static_cast<uint8_t>(_data.m_commandType)
+                       << "; arg1: " << _data.m_arg1 << "; arg2: " << _data.m_arg2;
+        }
+    } // namespace tools_api
+} // namespace dds

--- a/dds-tools-lib/src/ToolsProtocol.h
+++ b/dds-tools-lib/src/ToolsProtocol.h
@@ -332,6 +332,44 @@ namespace dds
 
         /// \brief Request class of onTaskDone.
         using SOnTaskDoneRequest = SBaseRequestImpl<SOnTaskDoneRequestData, SOnTaskDoneResponseData>;
+
+        /// \brief Structure holds information of agentCommand request.
+        struct SAgentCommandRequestData : SBaseRequestData<SAgentCommandRequestData>
+        {
+
+            SAgentCommandRequestData();
+            SAgentCommandRequestData(const boost::property_tree::ptree& _pt);
+
+            enum class EAgentCommandType : uint8_t
+            {
+                shutDownByID = 0, ///<  m_arg1 should be set to a desired agent ID to shutdown
+                shutDownBySlotID, ///<  m_arg1 should be set to a desired slot ID. The corresponding agent holding this
+                                  ///<  slot will be shutdown.
+                // stopTaskByTaskID,
+                // stopTaskByAgentID,
+                // restartTaskByTaskID,
+                // restartTaskByAgentID
+            };
+
+            EAgentCommandType m_commandType = EAgentCommandType::shutDownByID;
+            uint64_t m_arg1{ 0 }; ///< argument #1 - numeric. The usage depends on the command.
+            std::string m_arg2;   ///< argument #1 - string.  The usage depends on the command.
+
+          private:
+            friend SBaseData<SAgentCommandRequestData>;
+            void _fromPT(const boost::property_tree::ptree& _pt);
+            void _toPT(boost::property_tree::ptree& _pt) const;
+            static constexpr const char* _protocolTag = "agentCommand";
+
+          public:
+            /// \brief Equality operator.
+            bool operator==(const SAgentCommandRequestData& _val) const;
+            /// \brief Ostream operator.
+            friend std::ostream& operator<<(std::ostream& _os, const SAgentCommandRequestData& _data);
+        };
+
+        /// \brief Request class of submit.
+        using SAgentCommandRequest = SBaseRequestImpl<SAgentCommandRequestData, SEmptyResponseData>;
     } // namespace tools_api
 } // namespace dds
 

--- a/dds-tools-lib/src/ToolsProtocolCore.h
+++ b/dds-tools-lib/src/ToolsProtocolCore.h
@@ -89,6 +89,12 @@
                 "exitCode": 123,
                 "signal": 123
             }
+            "agentCommand":
+            {
+                "command": 123,
+                "arg1": 123,
+                "arg2": "string"
+            }
         }
     }
 }

--- a/dds-tools-lib/tests/TestProtocol.cpp
+++ b/dds-tools-lib/tests/TestProtocol.cpp
@@ -224,6 +224,21 @@ BOOST_AUTO_TEST_CASE(test_dds_tools_protocol)
 
             BOOST_CHECK(data == testData);
         }
+        else if (tag == "agentCommand")
+        {
+            SAgentCommandRequestData testData;
+            testData.m_commandType = SAgentCommandRequestData::EAgentCommandType::shutDownByID;
+            testData.m_arg1 = 235;
+            testData.m_arg2 = "testString";
+
+            SAgentCommandRequestData data(child.second);
+
+            // Test availability of the stream insertion
+            stringstream ss;
+            ss << data;
+
+            BOOST_CHECK(data == testData);
+        }
     }
 }
 


### PR DESCRIPTION
Added: A new `SAgentCommandRequest` request to shutdown agents by ID or by slotID. (GH-399)