### PR TITLE
GH-407: Add agent groups support

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,7 +4,13 @@
 
 ### DDS common
 
-Added: every DDS module logs now its pid, group id and parent pid. (GH-403)     
+Added: every DDS module logs now its pid, group id and parent pid. (GH-403)    
+
+### dds-submit
+Added: Users can specify a GroupName tag for each submission. This tag will be assigned to agents and can be used as a requirement in topologies. (GH-407)     
+
+### dds-topology
+Added: A new groupName requirement. It can be used on task and collection. (GH-407)   
 
 ## v3.6 (2022-01-11)
 

--- a/bin/dds-prep-worker
+++ b/bin/dds-prep-worker
@@ -29,9 +29,10 @@ DDS command line utility to prepare a worker package - all elements of DDS which
 Usage: $(basename $0) [OPTION]
      -i 			Re-pack user_worker_env.sh (for internal use only).
 	 -s arg			Submit time (optional).
-	 -a arg         DDS Session ID
-	 -t arg         A number of task slots
-	 -l             Create a lightweight package, without WN binaries
+	 -a arg         DDS Session ID.
+	 -t arg         A number of task slots.
+	 -g arg         Agent group name.
+	 -l             Create a lightweight package, without WN binaries.
      -h          	Show summary of options.
 
 Report bugs to http://dds.gsi.de
@@ -45,7 +46,8 @@ SUBMIT_TIME=""
 DDS_SESSION_ID=""
 LIGHTWEIGHT_PKG=""
 DDS_AGENT_SLOTS=""
-while getopts ":is:a:t:lh" opt; do
+AGENT_GROUP_NAME=""
+while getopts ":is:a:t:g:lh" opt; do
   case $opt in
   	i)
        REPACK_WRK_PKG="YES"
@@ -55,6 +57,8 @@ while getopts ":is:a:t:lh" opt; do
 	a) DDS_SESSION_ID="$OPTARG"
 	    ;;
 	t) DDS_AGENT_SLOTS="$OPTARG"
+	    ;;
+	g) AGENT_GROUP_NAME="$OPTARG"
 	    ;;
 	l) LIGHTWEIGHT_PKG="YES"
 		;;
@@ -301,6 +305,11 @@ mv "$DDS_WRK_TMP_DIR/DDSWorker.sh.temp" $DDS_WRK_SCRIPT_TMP
 # Replace a number of task slot variable with the actual value
 echo "$TOOL_NAME: setting agent task slots to $DDS_AGENT_SLOTS"
 LANG=C LC_ALL=C sed -i.back "s/_DDS_AGENT_SLOTS_/$DDS_AGENT_SLOTS/g" $DDS_WRK_SCRIPT_TMP
+rm -f "$DDS_WRK_SCRIPT_TMP.back"
+
+# Replace a group name variable with the actual value
+echo "$TOOL_NAME: setting agent group[ name to $AGENT_GROUP_NAME"
+LANG=C LC_ALL=C sed -i.back "s/_AGENT_GROUP_NAME_/$AGENT_GROUP_NAME/g" $DDS_WRK_SCRIPT_TMP
 rm -f "$DDS_WRK_SCRIPT_TMP.back"
 
 # copy worker script to the sandbox directory

--- a/dds-agent/src/AgentConnectionManager.cpp
+++ b/dds-agent/src/AgentConnectionManager.cpp
@@ -167,6 +167,7 @@ void CAgentConnectionManager::createCommanderChannel(uint64_t _protocolHeaderID)
     // Create new agent and push handshake message
     m_commanderChannel = CCommanderChannel::makeNew(m_context, _protocolHeaderID, m_intercomContext);
     m_commanderChannel->setNumberOfSlots(m_options.m_slots);
+    m_commanderChannel->setGroupName(m_options.m_groupName);
 
     // Subscribe to Shutdown command
     m_commanderChannel->registerHandler<cmdSHUTDOWN>(

--- a/dds-agent/src/CommanderChannel.cpp
+++ b/dds-agent/src/CommanderChannel.cpp
@@ -129,6 +129,11 @@ void CCommanderChannel::setNumberOfSlots(size_t _nSlots)
     m_nSlots = _nSlots;
 }
 
+void CCommanderChannel::setGroupName(const std::string& _groupName)
+{
+    m_groupName = _groupName;
+}
+
 bool CCommanderChannel::on_cmdREPLY(SCommandAttachmentImpl<cmdREPLY>::ptr_t _attachment, SSenderInfo& /*_sender*/)
 {
     switch (_attachment->m_srcCommand)
@@ -221,6 +226,7 @@ bool CCommanderChannel::on_cmdGET_HOST_INFO(SCommandAttachmentImpl<cmdGET_HOST_I
     cmd.m_DDSPath = CUserDefaults::getDDSPath();
     cmd.m_agentPid = pid;
     cmd.m_slots = m_nSlots;
+    cmd.m_groupName = m_groupName;
 
     // get worker ID
     string sWorkerId;
@@ -241,6 +247,8 @@ bool CCommanderChannel::on_cmdGET_HOST_INFO(SCommandAttachmentImpl<cmdGET_HOST_I
         sSubmitTime.assign(pchSubmitTime);
         cmd.m_submitTime = stoll(sSubmitTime);
     }
+
+    LOG(info) << cmd;
 
     pushMsg<cmdREPLY_HOST_INFO>(cmd);
     return true;

--- a/dds-agent/src/CommanderChannel.h
+++ b/dds-agent/src/CommanderChannel.h
@@ -72,6 +72,7 @@ namespace dds
           public:
             void stopChannel();
             void setNumberOfSlots(size_t _nSlots);
+            void setGroupName(const std::string& _groupName);
 
           private:
             // Message Handlers
@@ -151,6 +152,7 @@ namespace dds
             SSlotInfo::container_t m_slots;
             size_t m_nSlots{ 0 };
             timerPtr_t m_resourceMonitorTimer;
+            std::string m_groupName;
         };
     } // namespace agent_cmd
 } // namespace dds

--- a/dds-agent/src/Options.h
+++ b/dds-agent/src/Options.h
@@ -46,6 +46,7 @@ namespace dds
 
             ECommands m_Command{ cmd_start };
             size_t m_slots{ 0 };
+            std::string m_groupName;
         } SOptions_t;
 
         // Command line parser
@@ -69,6 +70,8 @@ namespace dds
                                   "   clean: \tCleaning");
             options.add_options()(
                 "slots,s", bpo::value<size_t>(&_options->m_slots), "Defines a number of task slots per agent.");
+            options.add_options()(
+                "group-name,g", bpo::value<std::string>(&_options->m_groupName), "Defines a group name of the agent.");
 
             //...positional
             bpo::positional_options_description pd;

--- a/dds-commander/src/ConnectionManager.cpp
+++ b/dds-commander/src/ConnectionManager.cpp
@@ -122,7 +122,10 @@ void CConnectionManager::newClientCreated(CAgentChannel::connectionPtr_t _newCli
 }
 
 //=============================================================================
-void CConnectionManager::_createWnPkg(bool _needInlineBashScript, bool _lightweightPkg, uint32_t _nSlots) const
+void CConnectionManager::_createWnPkg(bool _needInlineBashScript,
+                                      bool _lightweightPkg,
+                                      uint32_t _nSlots,
+                                      const string& _groupName) const
 {
     // re-create the worker package if needed
     string out;
@@ -145,6 +148,9 @@ void CConnectionManager::_createWnPkg(bool _needInlineBashScript, bool _lightwei
         // Slots per agent
         cmd += " -t ";
         cmd += to_string(_nSlots);
+        // Group name
+        cmd += " -g ";
+        cmd += _groupName;
 
         if (_lightweightPkg)
             cmd += " -l ";
@@ -1015,7 +1021,10 @@ void CConnectionManager::submitAgents(const dds::tools_api::SSubmitRequestData& 
         sendToolsAPIMsg(_channel, _submitInfo.m_requestID, "Creating new worker package...", EMsgSeverity::info);
 
         // Use a lightweightpackage when possible
-        _createWnPkg(!inlineShellScripCmds.empty(), (_submitInfo.m_rms == "localhost"), _submitInfo.m_slots);
+        _createWnPkg(!inlineShellScripCmds.empty(),
+                     (_submitInfo.m_rms == "localhost"),
+                     _submitInfo.m_slots,
+                     _submitInfo.m_groupName);
 
         // remember the UI channel, which requested to submit the job
         m_SubmitAgents.m_channel = _channel;
@@ -1027,6 +1036,7 @@ void CConnectionManager::submitAgents(const dds::tools_api::SSubmitRequestData& 
         submitRequest.m_nInstances = _submitInfo.m_instances;
         submitRequest.m_slots = _submitInfo.m_slots;
         submitRequest.m_wrkPackagePath = CUserDefaults::instance().getWrkScriptPath();
+        submitRequest.m_groupName = _submitInfo.m_groupName;
         m_SubmitAgents.m_strInitialSubmitRequest = submitRequest.toJSON();
 
         string sPluginInfoMsg("RMS plug-in: ");

--- a/dds-commander/src/ConnectionManager.h
+++ b/dds-commander/src/ConnectionManager.h
@@ -101,7 +101,10 @@ namespace dds
             void activateTasks(const dds::tools_api::STopologyRequestData& _topologyInfo,
                                const CScheduler& _scheduler,
                                CAgentChannel::weakConnectionPtr_t _channel);
-            void _createWnPkg(bool _needInlineBashScript, bool _lightweightPkg, uint32_t _nSlots) const;
+            void _createWnPkg(bool _needInlineBashScript,
+                              bool _lightweightPkg,
+                              uint32_t _nSlots,
+                              const std::string& _groupName) const;
             void processToolsAPIRequests(const protocol_api::SCustomCmdCmd& _cmd,
                                          CAgentChannel::weakConnectionPtr_t _channel);
             void submitAgents(const dds::tools_api::SSubmitRequestData& _submitInfo,

--- a/dds-commander/src/Scheduler.h
+++ b/dds-commander/src/Scheduler.h
@@ -37,8 +37,9 @@ namespace dds
             using weakChannelInfoVector_t = std::vector<dds::protocol_api::SWeakChannelInfo<CAgentChannel>>;
 
           private:
-            // Map tuple<agent ID, host name, worker id> to vector of channel indeces.
-            using hostToChannelMap_t = std::map<std::tuple<uint64_t, std::string, std::string>, std::vector<size_t>>;
+            // Map tuple<agent ID, host name, worker id, group name> to vector of channel indeces.
+            using hostToChannelMap_t =
+                std::map<std::tuple<uint64_t, std::string, std::string, std::string>, std::vector<size_t>>;
             // Map pair<host name, task/collection name> to counter.
             using hostCounterMap_t = std::map<std::pair<std::string, std::string>, size_t>;
 
@@ -82,9 +83,11 @@ namespace dds
                                const topology_api::CTopoCore::IdSet_t* _addedTasks,
                                hostCounterMap_t& _hostCounterMap);
 
+            // TODO: host, wn and group names should be provided via a struct.
             bool checkRequirements(const topology_api::CTopoRequirement::PtrVector_t& _requirements,
                                    const std::string& _hostName,
                                    const std::string& _wnName,
+                                   const std::string& _groupName,
                                    const std::string& _elementName,
                                    hostCounterMap_t& _hostCounterMap) const;
 

--- a/dds-commander/tests/topology_scheduler_test_2.xml
+++ b/dds-commander/tests/topology_scheduler_test_2.xml
@@ -11,6 +11,10 @@
 	<declrequirement name="requirement5" type="wnname" value="wn5"/>
 
 	<declrequirement name="requirement6" type="wnname" value="wn6"/>
+	
+	<declrequirement name="requirement7" type="groupname" value="test_group"/>
+	
+	<declrequirement name="requirement8" type="groupname" value="test_group2"/>
 
   	<decltask name="TestTask1">
 		<exe reachable="false">test_task.exe</exe>
@@ -39,6 +43,13 @@
 			<name>requirement5</name>
 		</requirements>
 	</decltask>
+	
+  	<decltask name="TestTask5">
+		<exe reachable="false">test_task.exe</exe>
+		<requirements>
+			<name>requirement8</name>
+		</requirements>
+	</decltask>
 
 	<declcollection name="TestCollection1">
 		<requirements>
@@ -65,6 +76,17 @@
 			<name>TestTask1</name>
 		</tasks>
 	</declcollection>
+	
+	<declcollection name="TestCollection4">
+		<requirements>
+			<name>requirement7</name>
+		</requirements>
+		<tasks>
+			<name>TestTask1</name>
+			<name>TestTask2</name>
+			<name>TestTask3</name>
+		</tasks>
+	</declcollection>
 
 	<main name="main">
 		<group name="group1" n="3">
@@ -72,9 +94,11 @@
 			<task>TestTask2</task>
 			<task>TestTask3</task>
 			<task>TestTask4</task>
+			<task>TestTask5</task>
 			<collection>TestCollection1</collection>
 			<collection>TestCollection2</collection>
 			<collection>TestCollection3</collection>
+			<collection>TestCollection4</collection>
 		</group>
 	</main>
 

--- a/dds-intercom-lib/src/Intercom.h
+++ b/dds-intercom-lib/src/Intercom.h
@@ -168,6 +168,7 @@ namespace dds
             std::string m_cfgFilePath;    ///< Path to the configuration file.
             std::string m_id;             ///< ID for communication with DDS commander.
             std::string m_wrkPackagePath; ///< A full path of the agent worker package, which needs to be deployed.
+            std::string m_groupName;      /// < Agent group name
         };
 
         /// \brief Structure holds information of message notification.

--- a/dds-intercom-lib/src/dds_rms_plugin_protocol.cpp
+++ b/dds-intercom-lib/src/dds_rms_plugin_protocol.cpp
@@ -58,6 +58,7 @@ std::string SSubmit::toJSON()
     pt.put<int>("dds.plug-in.submit.slots", m_slots);
     pt.put<string>("dds.plug-in.submit.cfgFilePath", m_cfgFilePath);
     pt.put<string>("dds.plug-in.submit.wrkPackagePath", m_wrkPackagePath);
+    pt.put<string>("dds.plug-in.submit.groupName", m_groupName);
 
     stringstream json;
     write_json(json, pt);
@@ -81,12 +82,14 @@ void SSubmit::fromPT(const boost::property_tree::ptree& _pt)
     m_cfgFilePath = pt.get<string>("submit.cfgFilePath", "");
     m_wrkPackagePath = pt.get<string>("submit.wrkPackagePath", "");
     m_id = pt.get<string>("id");
+    m_groupName = pt.get<string>("submit.groupName", "");
 }
 
 bool SSubmit::operator==(const SSubmit& val) const
 {
     return (m_id == val.m_id) && (m_nInstances == val.m_nInstances) && (m_slots == val.m_slots) &&
-           (m_cfgFilePath == val.m_cfgFilePath) && (m_wrkPackagePath == val.m_wrkPackagePath);
+           (m_cfgFilePath == val.m_cfgFilePath) && (m_wrkPackagePath == val.m_wrkPackagePath) &&
+           (m_groupName == val.m_groupName);
 }
 
 ///////////////////////////////////

--- a/dds-protocol-lib/src/HostInfoCmd.cpp
+++ b/dds-protocol-lib/src/HostInfoCmd.cpp
@@ -13,25 +13,21 @@ SHostInfoCmd::SHostInfoCmd()
     : m_agentPid(0)
     , m_slots(0)
     , m_submitTime(0)
-    , m_username()
-    , m_host()
-    , m_version()
-    , m_DDSPath()
-    , m_workerId()
 {
 }
 
 size_t SHostInfoCmd::size() const
 {
     return dsize(m_username) + dsize(m_host) + dsize(m_agentPid) + dsize(m_slots) + dsize(m_submitTime) +
-           dsize(m_version) + dsize(m_DDSPath) + dsize(m_workerId);
+           dsize(m_version) + dsize(m_DDSPath) + dsize(m_workerId) + dsize(m_groupName);
 }
 
 bool SHostInfoCmd::operator==(const SHostInfoCmd& val) const
 {
     return (m_username == val.m_username && m_host == val.m_host && m_version == val.m_version &&
             m_DDSPath == val.m_DDSPath && m_agentPid == val.m_agentPid && m_slots == val.m_slots &&
-            m_submitTime == val.m_submitTime && m_submitTime == val.m_submitTime && m_workerId == val.m_workerId);
+            m_submitTime == val.m_submitTime && m_submitTime == val.m_submitTime && m_workerId == val.m_workerId &&
+            m_groupName == val.m_groupName);
 }
 
 void SHostInfoCmd::_convertFromData(const BYTEVector_t& _data)
@@ -44,7 +40,8 @@ void SHostInfoCmd::_convertFromData(const BYTEVector_t& _data)
         .get(m_host)
         .get(m_version)
         .get(m_DDSPath)
-        .get(m_workerId);
+        .get(m_workerId)
+        .get(m_groupName);
 }
 
 void SHostInfoCmd::_convertToData(BYTEVector_t* _data) const
@@ -57,14 +54,16 @@ void SHostInfoCmd::_convertToData(BYTEVector_t* _data) const
         .put(m_host)
         .put(m_version)
         .put(m_DDSPath)
-        .put(m_workerId);
+        .put(m_workerId)
+        .put(m_groupName);
 }
 
 std::ostream& dds::protocol_api::operator<<(std::ostream& _stream, const SHostInfoCmd& val)
 {
-    _stream << val.m_username << ":" << val.m_host << ": " << val.m_version << ":" << val.m_DDSPath << "; agent ["
-            << val.m_agentPid << "]; Task slots: " << val.m_slots << "startup time: " << val.m_submitTime
-            << "; worker ID:" << val.m_workerId;
+    _stream << "host: " << val.m_username << "@" << val.m_host << "; ver." << val.m_version
+            << "; dds path:" << val.m_DDSPath << "; agent [" << val.m_agentPid << "]; task slots: " << val.m_slots
+            << "startup time: " << val.m_submitTime << "; worker ID: " << val.m_workerId
+            << "; group Name: " << val.m_groupName;
     return _stream;
 }
 

--- a/dds-protocol-lib/src/HostInfoCmd.h
+++ b/dds-protocol-lib/src/HostInfoCmd.h
@@ -30,6 +30,7 @@ namespace dds
             std::string m_version;
             std::string m_DDSPath;
             std::string m_workerId;
+            std::string m_groupName; // Agent group name. Defined on submission.
         };
         std::ostream& operator<<(std::ostream& _stream, const SHostInfoCmd& val);
         bool operator!=(const SHostInfoCmd& lhs, const SHostInfoCmd& rhs);

--- a/dds-protocol-lib/tests/Test_ProtocolMessage.cpp
+++ b/dds-protocol-lib/tests/Test_ProtocolMessage.cpp
@@ -88,7 +88,7 @@ BOOST_AUTO_TEST_CASE(Test_ProtocolMessage_cmdSUBMIT)
 
 BOOST_AUTO_TEST_CASE(Test_ProtocolMessage_cmdREPLY_HOST_INFO)
 {
-    const unsigned int cmdSize = 67;
+    const unsigned int cmdSize = 78;
 
     SHostInfoCmd cmd;
     cmd.m_username = "username";
@@ -99,6 +99,7 @@ BOOST_AUTO_TEST_CASE(Test_ProtocolMessage_cmdREPLY_HOST_INFO)
     cmd.m_slots = 10;
     cmd.m_submitTime = 23465677;
     cmd.m_workerId = "wn5";
+    cmd.m_groupName = "TestGroup";
 
     TestCommand(cmd, cmdREPLY_HOST_INFO, cmdSize);
 }

--- a/dds-submit/src/main.cpp
+++ b/dds-submit/src/main.cpp
@@ -92,6 +92,7 @@ int main(int argc, char* argv[])
         requestInfo.m_instances = options.m_number;
         requestInfo.m_slots = options.m_slots;
         requestInfo.m_pluginPath = options.m_sPath;
+        requestInfo.m_groupName = options.m_groupName;
         SSubmitRequest::ptr_t requestPtr = SSubmitRequest::makeRequest(requestInfo);
 
         requestPtr->setMessageCallback(

--- a/dds-tools-lib/src/ToolsProtocol.cpp
+++ b/dds-tools-lib/src/ToolsProtocol.cpp
@@ -178,6 +178,7 @@ void SSubmitRequestData::_toPT(boost::property_tree::ptree& _pt) const
     _pt.put<string>("config", m_config);
     _pt.put<string>("rms", m_rms);
     _pt.put<string>("pluginPath", m_pluginPath);
+    _pt.put<string>("groupName", m_groupName);
 }
 
 void SSubmitRequestData::_fromPT(const boost::property_tree::ptree& _pt)
@@ -187,12 +188,14 @@ void SSubmitRequestData::_fromPT(const boost::property_tree::ptree& _pt)
     m_config = _pt.get<string>("config", "");
     m_rms = _pt.get<string>("rms", "");
     m_pluginPath = _pt.get<string>("pluginPath", "");
+    m_groupName = _pt.get<string>("groupName", "");
 }
 
 bool SSubmitRequestData::operator==(const SSubmitRequestData& _val) const
 {
     return (SBaseData::operator==(_val) && m_rms == _val.m_rms && m_instances == _val.m_instances &&
-            m_slots == _val.m_slots && m_config == _val.m_config && m_pluginPath == _val.m_pluginPath);
+            m_slots == _val.m_slots && m_config == _val.m_config && m_pluginPath == _val.m_pluginPath &&
+            m_groupName == _val.m_groupName);
 }
 
 // We need to put function implementation in the same "dds::tools_api" namespace as a friend function declaration.
@@ -206,7 +209,7 @@ namespace dds
         {
             return _os << _data.defaultToString() << "; instances: " << _data.m_instances
                        << "; slots: " << _data.m_slots << "; config: " << _data.m_config << "; rms: " << _data.m_rms
-                       << "; pluginPath: " << _data.m_pluginPath;
+                       << "; pluginPath: " << _data.m_pluginPath << "; groupName: " << _data.m_groupName;
         }
     } // namespace tools_api
 } // namespace dds

--- a/dds-tools-lib/src/ToolsProtocol.h
+++ b/dds-tools-lib/src/ToolsProtocol.h
@@ -85,6 +85,7 @@ namespace dds
             uint32_t m_slots = 0;     /// < Number of task slots.
             std::string m_config;     ///< Path to the configuration file.
             std::string m_pluginPath; ///< Optional. A plug-in's directory search path
+            std::string m_groupName;  ///<  A group name of agents.
 
           private:
             friend SBaseData<SSubmitRequestData>;

--- a/dds-topology-lib/src/TopoRequirement.h
+++ b/dds-topology-lib/src/TopoRequirement.h
@@ -25,7 +25,8 @@ namespace dds
                 WnName,
                 HostName,
                 Gpu,
-                MaxInstancesPerHost
+                MaxInstancesPerHost,
+                GroupName
             };
 
             using Ptr_t = std::shared_ptr<CTopoRequirement>;

--- a/dds-topology-lib/src/TopoUtils.cpp
+++ b/dds-topology-lib/src/TopoUtils.cpp
@@ -157,6 +157,8 @@ namespace dds
                 return CTopoRequirement::EType::Gpu;
             if (_name == "maxinstances")
                 return CTopoRequirement::EType::MaxInstancesPerHost;
+            if (_name == "groupname")
+                return CTopoRequirement::EType::GroupName;
             else
                 throw runtime_error("Host pattern type with name " + _name + " does not exist.");
         }
@@ -173,6 +175,8 @@ namespace dds
                     return "gpu";
                 case CTopoRequirement::EType::MaxInstancesPerHost:
                     return "maxinstances";
+                case CTopoRequirement::EType::GroupName:
+                    return "groupname";
                 default:
                     throw runtime_error("Topology element not found.");
             }

--- a/etc/DDSWorker.sh.in
+++ b/etc/DDSWorker.sh.in
@@ -353,9 +353,9 @@ do
 
    # _DDS_AGENT_SLOTS_ is replaced (set) by the dds-prep-worker
    if [ -n "$2" ]; then
-	   $dds_agent start --slots $2&
+	   $dds_agent start --slots $2 --group-name _AGENT_GROUP_NAME_&
    else
-   	   $dds_agent start --slots _DDS_AGENT_SLOTS_&
+   	   $dds_agent start --slots _DDS_AGENT_SLOTS_ --group-name _AGENT_GROUP_NAME_&
    fi
    # wait for dds-agent's process
    DDSAGENT_PID=$!

--- a/res/topology.xsd
+++ b/res/topology.xsd
@@ -48,12 +48,6 @@
 	<xs:attribute name="value" type="xs:string" use="required"/>
 </xs:complexType>
 
-<xs:complexType name="mainGroupType">
-	<xs:attribute name="name" type="stringNameType" use="required"/>
-	<xs:attribute name="n" type="sizeType" use="required"/>
-</xs:complexType>
-
-
 <xs:complexType name="exeType">
    <xs:simpleContent>
        <xs:extension base="stringType">
@@ -109,6 +103,7 @@
   <xs:restriction base="xs:string">
     <xs:enumeration value="wnname"/>
     <xs:enumeration value="hostname"/>
+	<xs:enumeration value="groupname"/>
     <xs:enumeration value="gpu"/>
     <xs:enumeration value="maxinstances"/>
   </xs:restriction>


### PR DESCRIPTION
dds-submit: Added: Users can specify a GroupName tag for each submission. This tag will be assigned to agents and can be used as a requirement in topologies. (GH-407)
dds-topology: Added: A new groupName requirement. It can be used on task and collection. (GH-407)