### PR TITLE
Allow setting DDS_LD_LIBRARY_PATH as CMake var

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -438,6 +438,9 @@ set(PREREQ_DIRS "$<TARGET_FILE_DIR:dds-user-defaults>::$<TARGET_FILE_DIR:dds_pro
 foreach(p IN LISTS ENV_LD_LIBRARY_PATH)
   set(PREREQ_DIRS "${PREREQ_DIRS}::${p}")
 endforeach()
+foreach(p IN LISTS DDS_LD_LIBRARY_PATH)
+  set(PREREQ_DIRS "${PREREQ_DIRS}::${p}")
+endforeach()
 
 set(DDS_AGENT_BIN_PATH $<TARGET_FILE:dds-agent>)
 set(DDS_PREREQ_SOURCE_BIN_PATH $<TARGET_FILE:dds-commander>)


### PR DESCRIPTION
Patch by @dennisklein

See: https://github.com/FairRootGroup/FairSoft/commit/3f1e93456e660a68d7393adbdbe2e9069f570a41