### PR TITLE
Add missing include

### DIFF
--- a/dds-misc-lib/src/SSHConfigFile.cpp
+++ b/dds-misc-lib/src/SSHConfigFile.cpp
@@ -6,6 +6,7 @@
 // std
 #include <iomanip>
 #include <iostream>
+#include <fstream>
 // boost
 #include <boost/tokenizer.hpp>
 // Misc


### PR DESCRIPTION
Without compilation on GCC 12.1 fails