### PR TITLE
GH-480: Fix topology update

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,10 @@
 # DDS Release Notes
 
+## v3.10 (2004-04-28)
+
+- DDS general
+  - Fixed: a regression bug causing topology update to fail on the hash validation. (GH-480)
+
 ## v3.9 (2024-04-23)
 
 - DDS general

--- a/dds-agent/src/CommanderChannel.cpp
+++ b/dds-agent/src/CommanderChannel.cpp
@@ -327,7 +327,7 @@ bool CCommanderChannel::on_cmdBINARY_ATTACHMENT_RECEIVED(
             {
                 const fs::path gzipPath{ bp::search_path("gzip") };
                 stringstream ssCmd;
-                ssCmd << gzipPath.string() << " -d " << destFilePath;
+                ssCmd << gzipPath.string() << " -df " << destFilePath;
                 string output;
                 execute(ssCmd.str(), chrono::seconds(60), &output);
                 // remove ".gz" extension


### PR DESCRIPTION
Fixed: a regression bug causing topology update to fail on the hash validation. (GH-480)