### PR TITLE
Fix new-delete-type-mismatch in BaseEventHandlersImpl.h

### DIFF
--- a/dds-protocol-lib/src/BaseEventHandlersImpl.h
+++ b/dds-protocol-lib/src/BaseEventHandlersImpl.h
@@ -53,6 +53,7 @@ namespace dds
         /// Helpers for event dispatching
         struct SHandlerHlpFunc
         {
+            virtual ~SHandlerHlpFunc() = default;
         };
         template <typename T>
         struct SHandlerHlpBaseFunc : SHandlerHlpFunc


### PR DESCRIPTION
Fixes #373, which continuously leads to test failures in ODC: https://cdash.gsi.de/testDetails.php?test=21606495&build=473806

The issue is that SHandlerHlpBaseFunc containing `T m_signal` is stored in a `std::map<Event_t, std::unique_ptr<SHandlerHlpFunc>> signalsContainer_t;`, with pointers to the base type. And since the base type has no virtual destructor, it then does not take care of deleting child's objects properly. 

I tested this change locally and it fixes the new-delete-type-mismatch.