### PR TITLE
docs: improve README structure and add comprehensive CLI documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,51 +5,72 @@
 [![fair-software.eu](https://img.shields.io/badge/fair--software.eu-%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8B%20%20%E2%97%8F%20%20%E2%97%8B-orange)](https://fair-software.eu)
 [![DOI](https://zenodo.org/badge/16586922.svg)](https://zenodo.org/badge/latestdoi/16586922)
 
-DDS - is a tool-set that automates and significantly simplifies a deployment of user defined processes and their dependencies on any resource management system using a given topology.
+DDS is a tool-set that automates and significantly simplifies the deployment of user-defined processes and their dependencies on any resource management system using a given topology.
 
-## Basic concepts
+## What is DDS?
 
-DDS:
+DDS is a tool-set that automates and significantly simplifies the deployment of user-defined processes and their dependencies on any resource management system using a given topology.
 
-- Implements a single-responsibility-principle command line toolset and APIs.
-- Treats users' tasks as black boxes.
-- Does not depend on RMS (provides deployment via SSH when no RMS is present).
-- Supports workers behind firewalls (outgoing connection from WNs required).
-- Does not require pre-installation on WNs.
-- Deploys private facilities on demand with isolated sandboxes.
-- Provides a key-value properties propagation service for tasks.
-- Provides rules-based execution of tasks.
+**Key Features:**
+
+* Works with any batch system (SLURM, LSF, PBS) or standalone via SSH
+* No pre-installation required on worker nodes
+* Supports distributed task communication via key-value properties
+* Provides isolated sandboxes for each deployment
+* Handles complex task dependencies and execution rules
+
+## Quick Start
+
+1. **Install DDS**: [Installation Guide](./docs/install.md)
+2. **First Run**: [Quick Start Guide](./docs/quick-start.md)
+3. **Learn by Example**: [Tutorials](./docs/tutorials.md)
 
 ## Documentation
 
-- [Requirements](./docs/requirements.md)
-- [Quick Start](./docs/quick-start.md)
-- [Download](./docs/download.md)
-- [Installation](./docs/install.md)
-- [How to Start](./docs/how-to-start.md)
-- [Topology description](./dds-topology-lib/README.md)
-- [Tutorials](./docs/tutorials.md)
-- Command-line interface
-  - [dds-session](dds-session/README.md)
-  - [dds-commander](dds-commander/README.md)
-  - [dds-user-defaults](dds-user-defaults/README.md)
-  - [dds-submit](dds-submit/README.md)
-  - [dds-info](dds-info/README.md)
-  - [dds-test](dds-test/README.md)
-  - [dds-topology](dds-topology/README.md)
-  - [dds-agent-cmd](dds-agent-cmd/README.md)
-- ToolsAPI documentation
-  - [dds-tools](./dds-tools-lib/README.md)
-- RMS plug-ins
-  - [localhost](./plugins/dds-submit-localhost/README.md)
-  - [ssh](./plugins/dds-submit-ssh/README.md)
-  - [slurm](./plugins/dds-submit-slurm/README.md)
-  - [lsf](./plugins/dds-submit-lsf/README.md)
-  - [pbs](./plugins/dds-submit-pbs/README.md)
-  - [For Plug-in developers](./plugins/README.md#for-plug-in-developers)
-- Additional docs
-  - [Build 3rd-party dependencies](./docs/3rd-party.md)
+### Getting Started
+
+* [Requirements](./docs/requirements.md) - System and network requirements
+* [Download](./docs/download.md) - Get DDS releases
+* [Installation](./docs/install.md) - Build and install from source
+* [Quick Start](./docs/quick-start.md) - Run your first DDS deployment
+* [How to Start](./docs/how-to-start.md) - Detailed usage guide
+
+### Configuration and Usage
+
+* [User Defaults Configuration](./docs/user-defaults-configuration.md) - Customize DDS behavior
+* [Topology description](./dds-topology-lib/README.md) - Define your task workflows  
+* [Tutorials](./docs/tutorials.md) - Step-by-step examples
+
+### Command-Line Tools
+
+* [dds-session](dds-session/README.md) - Session management
+* [dds-commander](dds-commander/README.md) - Core server component
+* [dds-user-defaults](dds-user-defaults/README.md) - Configuration management
+* [dds-submit](dds-submit/README.md) - Agent deployment
+* [dds-info](dds-info/README.md) - Status and monitoring
+* [dds-test](dds-test/README.md) - Testing utilities
+* [dds-topology](dds-topology/README.md) - Topology management
+* [dds-agent-cmd](dds-agent-cmd/README.md) - Agent commands
+
+### Development APIs
+
+* [dds-tools](./dds-tools-lib/README.md) - C++ API for DDS integration
+
+### Resource Management Plugins
+
+* [localhost](./plugins/dds-submit-localhost/README.md) - Local machine deployment
+* [ssh](./plugins/dds-submit-ssh/README.md) - SSH-based deployment
+* [slurm](./plugins/dds-submit-slurm/README.md) - SLURM integration
+* [lsf](./plugins/dds-submit-lsf/README.md) - LSF integration
+* [pbs](./plugins/dds-submit-pbs/README.md) - PBS integration
+* [For Plug-in developers](./plugins/README.md#for-plug-in-developers) - Creating custom plugins
+
+### Additional Documentation
+
+* [Build 3rd-party dependencies](./docs/3rd-party.md) - Development setup
 
 ## Links
 
-- [User's manual](http://dds.gsi.de/documentation.html)
+* [Latest Release](https://github.com/FairRootGroup/DDS/releases/latest)
+* [User's Manual](https://github.com/FairRootGroup/DDS/blob/master/docs/)
+* [All Releases](https://github.com/FairRootGroup/DDS/releases)

--- a/dds-agent-cmd/README.md
+++ b/dds-agent-cmd/README.md
@@ -1,44 +1,65 @@
 # dds-agent-cmd
 
-Send commands to agent. **UNIX/Linux/OSX**
+Send commands to DDS agents. **UNIX/Linux/OSX**
 
 ## Synopsis
 
 ```shell
-dds-agent-cmd [[-h, --help] | [-v, --version] | [command, --command arg] | [-s, --session arg]] {[getlog arg] {[-a, --all]} | [update-key arg] {[--key arg] | [--value arg]}}
+dds-agent-cmd [[-h, --help] | [-v, --version]] [--verbose] [-s, --session arg] {getlog [-a, --all]}
 ```
 
 ## Description
 
-This utility allows to send commands to DDS agents.  
-For the currently available commands see [Options](#options)
+This utility allows you to send commands to DDS agents.  
+Currently supports retrieving log files from worker nodes.
 
 ## Options
 
-* **getlog** *arg*  
-Download all log files from active agents. All files from agents' working directories with the extension `.log` will be tar/zip'ed into a single file and downloaded on DDS commander server machine into the directory specified by `server.log_dir` DDS configuration option and placed in the subdirectory "agents" (default:`~/.DDS/log/agents`)  
-Usage example:
+* **-h, --help**  
+Show usage options.
 
-  ```shell
-  dds-agent-cmd getlog -a
-  ```
+* **-v, --version**  
+Show version information.
 
-* **update-key** *arg*  
-It forces an update of a given task's property in the topology. Name of the property and a new value should be provided additionally (see `--key` and `--value`)  
-Usage example:
+* **--verbose**  
+Enable verbose output.
 
-  ```shell
-  dds-agent-cmd update-key --key mykey --value new_value
-  ```
+* **-s, --session** *arg*  
+DDS Session ID.
 
-* **--key**  
-Defines the key to update
-
-* **--value**  
-Defines a new value of the given key.
+* **getlog**  
+Download all log files from active agents. All files from agents' working directories with the extension `.log` will be tar/zip'ed into a single file and downloaded to the DDS commander server machine into the directory specified by `server.log_dir` DDS configuration option and placed in the subdirectory "agents" (default: `~/.DDS/log/agents`). For more details about this configuration option, see the [User Defaults Configuration Reference](../docs/user-defaults-configuration.md).
 
 * **-a, --all**  
-Send command to all active agents.
+Send command to all active agents. Must be used with `getlog` command.
 
-* **--s, --session** *arg*  
-DDS Session ID.
+## Examples
+
+### Download log files from all active agents
+
+```console
+$ dds-agent-cmd getlog --all
+Retrieving log files from worker nodes...
+Files will be saved in ~/.DDS/sessions/12345678-1234-1234-1234-123456789abc/log/agents
+Log files downloaded successfully.
+```
+
+### Download log files with verbose output
+
+```console
+$ dds-agent-cmd getlog --all --verbose
+Sending getlog command to all active agents...
+Agent 12345678: Collecting log files...
+Agent 12345679: Collecting log files...
+Files are being downloaded to ~/.DDS/sessions/12345678-1234-1234-1234-123456789abc/log/agents
+Download completed successfully.
+```
+
+### Download log files for specific session
+
+```console
+$ dds-agent-cmd getlog --all --session 87654321-4321-4321-4321-210987654321
+Retrieving log files from worker nodes...
+Files will be saved in ~/.DDS/sessions/87654321-4321-4321-4321-210987654321/log/agents
+Log files downloaded successfully.
+```

--- a/dds-info/README.md
+++ b/dds-info/README.md
@@ -1,48 +1,129 @@
 # dds-info
 
-It an be used to query different kinds of information from DDS commander server. **UNIX/Linux/OSX**
+Query different kinds of information from DDS commander server. **UNIX/Linux/OSX**
 
 ## Synopsis
 
 ```shell
-dds-info [[-h, --help] | [-v, --version]] [[-s, --session arg] | [--commander-pid] | [--status] | [-n, --active-count] | [-l, --agents-list] | [--idle-count] | [--executing-count] | [--wait-count arg] | [--active-topology]]
+dds-info [[-h, --help] | [-v, --version]] [[-s, --session arg] | [--commander-pid] | [--status] | [-n, --active-count] | [-l, --agent-list] | [--slot-list] | [--idle-count] | [--executing-count] | [--wait arg] | [--active-topology]]
 ```
 
 ## Description
 
-The command can be used to query different kinds of information from DDS commander server.
+The command can be used to query different kinds of information from DDS commander server, including agent status, slot counts, topology information, and server process details.
 
 ## Options
 
 * **-h, --help**  
-Shows usage options.
+Show usage options.
 
 * **-v, --version**  
-Shows version information.
+Show version information.
 
-* **-s, --session arg**  
+* **-s, --session** *arg*  
 DDS Session ID.
 
 * **--commander-pid**  
-Return the pid of the commander server.
+Return the process ID (PID) of the commander server.
 
 * **--status**  
 Query current status of DDS commander server.
 
 * **-n, --active-count**  
-Returns a number of online slots.
+Return the number of online slots.
 
-* **-l, --agents-list**  
-Show detailed info about all online agents.
+* **-l, --agent-list**  
+Show detailed information about all online agents.
+
+* **--slot-list**  
+Show detailed information about all online slots.
 
 * **--idle-count**  
-Returns a number of idle slots.
+Return the number of idle slots.
 
 * **--executing-count**  
-Returns a number of executing slots.
+Return the number of executing slots.
 
-* **--wait-count** *arg*  
-The command will block infinitely until a required number of agents are available. Must be used together with `--active-count`, `--idle-count` or `--executing-count`.
+* **--wait** *arg*  
+The command will block infinitely until a required number of slots are available. Must be used together with `--active-count`, `--idle-count`, or `--executing-count`. The argument specifies the minimum number of slots to wait for.
 
 * **--active-topology**  
-Returns the name of the active topology.
+Return the name and path of the active topology.
+
+## Examples
+
+### Check commander server status
+
+```console
+$ dds-info --status
+DDS commander server process (12345) is running...
+```
+
+### Get commander server process ID
+
+```console
+$ dds-info --commander-pid
+12345
+```
+
+### Get number of active slots
+
+```console
+$ dds-info --active-count
+50
+```
+
+### Get number of idle slots
+
+```console
+$ dds-info --idle-count
+25
+```
+
+### Get number of executing slots
+
+```console
+$ dds-info --executing-count
+25
+```
+
+### List all online agents
+
+```console
+$ dds-info --agent-list
+Agent 0: id (12345678), pid (98765), group name (common), startup time (1.23s), slots total/executing/idle (10/5/5), host (user@hostname), wrkDir ("/tmp/dds_wn_12345")
+Agent 1: id (12345679), pid (98766), group name (common), startup time (1.45s), slots total/executing/idle (10/0/10), host (user@hostname), wrkDir ("/tmp/dds_wn_12346")
+```
+
+### List all online slots
+
+```console
+$ dds-info --slot-list
+Slot 0: agentID (12345678), slotID (1), taskID (task_1), state (executing), host (hostname), wrkDir ("/tmp/dds_wn_12345/slot_1")
+Slot 1: agentID (12345678), slotID (2), taskID (0), state (idle), host (hostname), wrkDir ("/tmp/dds_wn_12345/slot_2")
+```
+
+### Get active topology information
+
+```console
+$ dds-info --active-topology
+active topology: example_topology; path: /path/to/topology.xml
+```
+
+### Wait for a specific number of active slots
+
+```console
+$ dds-info --active-count --wait 100
+Active agents online: 100
+Idle agents online: 50
+Executing agents online: 50
+```
+
+### Wait for idle slots to become available
+
+```console
+$ dds-info --idle-count --wait 10
+Active agents online: 75
+Idle agents online: 10
+Executing agents online: 65
+```

--- a/dds-session/README.md
+++ b/dds-session/README.md
@@ -5,22 +5,28 @@ Start/Stop DDS commander and manage DDS sessions. **UNIX/Linux/OSX**
 ## Synopsis
 
 ```shell
-dds-session {[[start [--mixed] [--lightweight]] | [stop SESSION_ID] | [stop_all] | [list all | run]] | [set-default SESSION_ID] | [clean -f]}
+dds-session [[-h, --help] | [-v, --version]] {[start [--mixed] [--lightweight]] | [stop [SESSION_ID]] | [stop-all] | [list {all | run}] | [set-default SESSION_ID] | [clean [-f, --force]]}
 ```
 
 ## Description
 
-Using this command users can perform a set of operations on DDS sessions, such as start/stop DDS server by creating new and stopping existing sessions. Users can also list available sessions or clean expired ones.
+Using this command users can perform a set of operations on DDS sessions, such as starting/stopping DDS server by creating new and stopping existing sessions. Users can also list available sessions or clean expired ones.
 
-One user can start multiple DDS sessions. Each session will have its own DDS commander instance and will be sandboxed, i.e. won't disturb other sessions of the same user.
+One user can start multiple DDS sessions. Each session will have its own DDS commander instance and will be sandboxed, i.e., won't interfere with other sessions of the same user.
 
 ## Options
 
+* **-h, --help**  
+Show usage options.
+
+* **-v, --version**  
+Show version information.
+
 * **start**  
-Start a new DDS session. DDS will automatically set the newly created session as a default one.
-A single user can start as many DDS sessions as desired. Users are limited only by the resources of underlying system.  
+Start a new DDS session. DDS will automatically set the newly created session as the default one.
+A single user can start as many DDS sessions as desired. Users are limited only by the resources of the underlying system.  
 Each DDS session spawns its own commander server. All sessions are completely isolated from each other.  
-At the server start DDS will test availability of DDS WN bin. packages and download them from the DDS repository if they are missing. If the user provides `--mixed parameter`, then WN packages for all systems (Linux, OS X) will be checked. By default DDS checks only for a package compatible with the local system only.  
+At server start, DDS will test availability of DDS worker node binary packages and download them from the DDS repository if they are missing. If the user provides the `--mixed` parameter, then worker node packages for all systems (Linux, OS X) will be checked. By default, DDS checks only for a package compatible with the local system.  
 To build a binary package for the local system, just issue:
 
   ```shell
@@ -32,32 +38,43 @@ To build a binary package for the local system, just issue:
   * `--mixed` - Use worker package for a mixed environment with agents on Linux and macOS simultaneously
   * `--lightweight` - Create lightweight worker packages without DDS binaries and libraries. This mode requires DDS to be pre-installed on worker nodes with proper environment variables set. Can also be enabled via `DDS_LIGHTWEIGHT_PACKAGE` environment variable.
 
-  **Lightweight Package Mode:**
-  When using `--lightweight` option or setting `DDS_LIGHTWEIGHT_PACKAGE=1`, DDS will skip worker package validation and create minimal packages (~50KB instead of ~15MB). Worker nodes must have:
-  * DDS pre-installed
-  * `DDS_COMMANDER_BIN_LOCATION` environment variable pointing to DDS binaries directory
-  * `DDS_COMMANDER_LIBS_LOCATION` environment variable pointing to DDS libraries directory
+* **stop** *[SESSION_ID]*  
+Stop a given DDS session specified by `SESSION_ID`. If no `SESSION_ID` argument is provided, the command will stop the default DDS session. In this case, the command will ask the user to confirm the choice unless `--force` is used.
 
-* **stop**  
-Stop a given DDS session specified by `SESSION_ID`. If no `SESSION_ID` argument is provided, the command will stop the default DDS session. But in this case the command will ask user to confirm the choice.
-
-* **stop_all**  
+* **stop-all**  
 Stop all running DDS sessions.
 
-* **list**  
-List available DDS sessions. User must provide the filter criteria, either all or run
-With all the command will list absolutely all existing sessions, including expired ones.
-With run the command will list only running DDS sessions.
+* **list** *{all | run}*  
+List available DDS sessions. User must provide the filter criteria:
+  * `all` - List absolutely all existing sessions, including expired ones
+  * `run` - List only running DDS sessions
 
-* **set-default**  
-Sets a given `SESSION_ID` as a default session ID.
-The default session ID is used by all DDS commands, when user doesn't provide a session ID explicitly in the command line arguments.
+* **set-default** *SESSION_ID*  
+Sets a given `SESSION_ID` as the default session ID.
+The default session ID is used by all DDS commands when the user doesn't provide a session ID explicitly in the command line arguments.
 
-* **clean**  
-The command cleans DDS sessions. It will remove all session related temporary files and logs. Be careful using this command. The operation can't be undone.
-For safety reason the command confirms with the user removal of each DDS session, but you can avoid this by providing the `-f` argument.
+* **clean** *[-f, --force]*  
+Clean DDS sessions. This will remove all session-related temporary files and logs. **Be careful using this command. The operation cannot be undone.**
+For safety reasons, the command confirms with the user the removal of each DDS session, but you can avoid this by providing the `-f` or `--force` argument.
 
-**Usage example:**
+## Environment Variables
+
+* **DDS_LIGHTWEIGHT_PACKAGE**  
+When set to `1`, `true`, `yes`, or `on` (case-insensitive), enables lightweight worker package mode. Command-line `--lightweight` option takes precedence over this environment variable.
+
+## Prerequisites for Lightweight Packages
+
+When using the `--lightweight` option or setting `DDS_LIGHTWEIGHT_PACKAGE=1`, DDS will skip worker package validation and create minimal packages (~50KB instead of ~15MB). Worker nodes **must** have:
+
+* DDS pre-installed
+* **DDS_COMMANDER_BIN_LOCATION** - Environment variable pointing to DDS binaries directory (e.g., `/opt/dds/bin`)
+* **DDS_COMMANDER_LIBS_LOCATION** - Environment variable pointing to DDS libraries directory (e.g., `/opt/dds/lib`)
+
+These variables should point to a valid DDS installation on the worker nodes. If not set or pointing to invalid locations, worker initialization will fail.
+
+## Examples
+
+### Start a new DDS session
 
 ```console
 $ dds-session start
@@ -76,13 +93,21 @@ Startup time: 1061.46 ms
 Default DDS session is set to cf84e72d-a3af-4fd8-af73-4337e9434612
 Currently running DDS sessions:
 cf84e72d-a3af-4fd8-af73-4337e9434612   [2018-08-22T11:53:34Z]   RUNNING
-    
+```
+
+### List all sessions
+
+```console
 $ dds-session list all
 
    cfc8e86d-157b-404e-bde8-a32f8b3c1331   [2018-08-21T13:49:35Z]   STOPPED    
    5fdc6142-497c-433c-8333-721f05eabe31   [2018-08-21T14:10:39Z]   STOPPED
  * cf84e72d-a3af-4fd8-af73-4337e9434612   [2018-08-22T11:53:34Z]   RUNNING
+```
 
+### Start lightweight session using command-line option
+
+```console
 $ dds-session start --lightweight
 
 DDS session ID: 12345678-1234-1234-1234-123456789abc
@@ -96,7 +121,11 @@ DDS commander is up and running.
 DDS commander server: 12345
 ------------------------
 Startup time: 142.56 ms
+```
 
+### Start lightweight session using environment variable
+
+```console
 $ export DDS_LIGHTWEIGHT_PACKAGE=1
 $ dds-session start
 
@@ -105,13 +134,26 @@ Starting DDS in lightweight mode - WN package validation skipped.
 Note: Workers must have DDS pre-installed with DDS_COMMANDER_BIN_LOCATION and DDS_COMMANDER_LIBS_LOCATION set.
 Starting DDS commander...
 ...
+```
 
-    
-    
+### Stop a specific session
+
+```console
 $ dds-session stop cf84e72d-a3af-4fd8-af73-4337e9434612
 
 Stopping DDS commander: cf84e72d-a3af-4fd8-af73-4337e9434612
 Sending a graceful stop signal to Commander (pid/sessionID): 60753/cf84e72d-a3af-4fd8-af73-4337e9434612
 dds-commander: self exiting (60753)...
-   
+```
+
+### Clean sessions with force option
+
+```console
+$ dds-session clean --force
+
+Removing: cfc8e86d-157b-404e-bde8-a32f8b3c1331
+    DDS Work dir: /tmp/dds_wn_1234/...
+    removed files count: 25
+    DDS Log dir: /tmp/dds_log_1234/...
+    removed files count: 8
 ```

--- a/dds-submit/README.md
+++ b/dds-submit/README.md
@@ -5,7 +5,7 @@ Submits and activates DDS agents. **UNIX/Linux/OSX**
 ## Synopsis
 
 ```shell
-dds-submit [[-h, --help] | [-v, --version]] [-l, --list] [-r, --rms arg] [-s, --session arg] [-c, --config arg] [-n, --number arg] [--min-instances arg] [--slots arg] [-g, --group-name arg] [-t, --submission-tag arg] [-e, --env-config arg] [--inline-config arg] [--enable-overbooking] [--lightweight]
+dds-submit [[-h, --help] | [-v, --version]] [-l, --list] [-r, --rms arg] [--path arg] [-s, --session arg] [-c, --config arg] [-n, --number arg] [--min-instances arg] [--slots arg] [-g, --group-name arg] [-t, --submission-tag arg] [-e, --env-config arg] [--inline-config arg] [--enable-overbooking] [--lightweight]
 ```
 
 ## Description
@@ -15,10 +15,10 @@ The command is used to submit DDS agents to allocate resources for user tasks. O
 ## Options
 
 * **-h, --help**  
-Shows usage options.  
+Show usage options.  
 
 * **-v, --version**  
-Shows version information.
+Show version information.
 
 * **-l, --list**  
 List all available RMS plug-ins.

--- a/dds-topology/README.md
+++ b/dds-topology/README.md
@@ -5,41 +5,112 @@ Topology related commands. **UNIX/Linux/OSX**
 ## Synopsis
 
 ```shell
-dds-topology [[-h, --help] | [-v, --version] | [-V, --verbose] [[--disable-validation]] | [-s, --session arg] | [--activate arg] | [--stop] | [--update arg] | [--validate arg] | [--topology-name arg]]
+dds-topology [[-h, --help] | [-v, --version]] [[-V, --verbose] [--disable-validation] [-s, --session arg]] {[--activate arg] | [--update arg] | [--stop] | [--validate arg] | [--required-agents arg] | [--topology-name arg]}
 ```
 
 ## Description
 
-This command allows to perform topology related tasks.
+This command allows you to perform topology-related tasks, including activating, updating, stopping, and validating DDS topologies.
 
 ## Options
 
 * **-h, --help**  
-Shows usage options.
+Show usage options.
 
 * **-v, --version**  
-Shows version information.
+Show version information.
 
 * **-V, --verbose**  
-Causes the command to verbose additional information and error messages.
+Cause the command to output additional information and error messages.
 
 * **--disable-validation**  
-Switches off topology validation.
+Switch off topology validation during activate, update, required-agents, or topology-name operations.
 
-* **--s, --session** *arg*  
+* **-s, --session** *arg*  
 DDS Session ID.
 
 * **--activate** *arg*  
-Requests DDS to activate agents, i.e. distribute and start user tasks according to the given topology.
+Request DDS to activate agents, i.e., distribute and start user tasks according to the given topology file.
 
 * **--update** *arg*  
-Requests DDS to update currently running topology with a new one.
+Request DDS to update the currently running topology with a new one.
 
 * **--stop**  
-Requests DDS to stop execution of user tasks. Stop the active topology.
+Request DDS to stop execution of user tasks. Stop the active topology.
 
 * **--validate** *arg*  
-Validates topology file against DDS's XSD schema.
+Validate topology file against DDS's XSD schema.
+
+* **--required-agents** *arg*  
+Get the required number of agents for the given topology file.
 
 * **--topology-name** *arg*  
-Get the name of the topology for a given topology file.
+Get the name of the topology from the given topology file.
+
+## Examples
+
+### Validate a topology file
+
+```console
+$ dds-topology --validate my_topology.xml
+Validating topology file: my_topology.xml
+Topology is valid.
+```
+
+### Activate a topology
+
+```console
+$ dds-topology --activate my_topology.xml
+Requesting to activate topology: my_topology.xml
+Topology has been activated.
+```
+
+### Update a running topology
+
+```console
+$ dds-topology --update new_topology.xml
+Requesting to update topology: new_topology.xml
+Topology has been updated.
+```
+
+### Stop the active topology
+
+```console
+$ dds-topology --stop
+Requesting to stop execution of user tasks.
+DDS agents have been stopped.
+```
+
+### Get topology name
+
+```console
+$ dds-topology --topology-name my_topology.xml
+MyTopologyName
+```
+
+### Get required number of agents
+
+```console
+$ dds-topology --required-agents my_topology.xml
+25
+```
+
+### Activate with verbose output
+
+```console
+$ dds-topology --activate my_topology.xml --verbose
+Validating topology file: my_topology.xml
+Topology is valid.
+Requesting to activate topology: my_topology.xml
+Distributing tasks to agents...
+All tasks have been successfully distributed.
+Topology has been activated.
+```
+
+### Activate without validation
+
+```console
+$ dds-topology --activate my_topology.xml --disable-validation
+Requesting to activate topology: my_topology.xml (validation disabled)
+Topology has been activated.
+```

--- a/dds-tutorials/dds-tutorial3/run_tutorial3.sh
+++ b/dds-tutorials/dds-tutorial3/run_tutorial3.sh
@@ -13,10 +13,10 @@ source ${location}/DDS_env.sh
 
 # Start DDS commander server
 echo "Starting DDS server..."
-startOutput=$(dds-session start --local)
+startOutput=$(dds-session start)
 echo "${startOutput}"
 
-# Extract session ID from "dds-session start --local" output
+# Extract session ID from "dds-session start" output
 sessionID=$(echo -e "${startOutput}" | head -1 | awk '{split($0,a,":"); print a[2]}' |  tr -d '[:space:]')
 echo "DDS session ID: ${sessionID}"
 

--- a/dds-user-defaults/README.md
+++ b/dds-user-defaults/README.md
@@ -5,46 +5,45 @@ Get and set global DDS options. **UNIX/Linux/OSX**
 ## Synopsis
 
 ```shell
-dds-user-defaults [[-h, --help] | [-v, --version] | [-V, --verbose] | [-p, --path] | [-d, --default]] [-c, --config arg] [-s, --session arg] [--submission-id arg] [--ignore-default-sid] [--default-session-id] [--default-session-id-file] [-f, --force] [[--key arg] | [--wrkpkg] | [--wrkscript] | [--rms-sandbox-dir] | [--user-env-script] | [--server-info-file] | [--session-id-file]]
+dds-user-defaults [[-h, --help] | [-v, --version]] [[-p, --path] | [-d, --default [-f, --force]] | [-c, --config arg] [-s, --session arg] [--submission-id arg] [--ignore-default-sid] [--default-session-id] [--default-session-id-file] [[--key arg] | [--wrkpkg] | [--wrkscript] | [--rms-sandbox-dir] | [--user-env-script] | [--server-info-file] | [--session-id-file]]]
 ```
 
 ## Description
 
-The **dds-user-defaults** command can be used to get and set global DDS options. It also can be used to get different static settings, related to the current deployment.
+The **dds-user-defaults** command can be used to get and set global DDS options. It can also be used to get different static settings related to the current deployment.
+
+For a comprehensive reference of all available configuration options, their defaults, and descriptions, see the [User Defaults Configuration Reference](../docs/user-defaults-configuration.md).
 
 ## Options
 
 * **-h, --help**  
-Shows usage options.
+Show usage options.
 
 * **-v, --version**  
-Shows version information.
-
-* **-V, --verbose**  
-Causes the command to verbose additional information and error messages.
+Show version information.
 
 * **-p, --path**  
-Shows default DDS user defaults config file path.
+Show default DDS user defaults config file path.
 
 * **-d, --default**  
-Generates a default DDS configuration file.
+Generate a default DDS configuration file.
 
 * **-f, --force**  
-If the destination file exists, removes it and creates a new file, without prompting for confirmation.  
-Can only be used with the `-d, --default` options.
+If the destination file exists, remove it and create a new file, without prompting for confirmation.  
+Can only be used with the `-d, --default` option.
 
 * **-c, --config** *arg*  
-This options can be used together with other options to specify non-default location of the DDS configuration file.  
+This option can be used together with other options to specify non-default location of the DDS configuration file.  
 By default the command uses `~/.DDS/DDS.cfg`.
 
 * **-s, --session** *arg*  
-Use the specified DDS Session ID instead of a default one.
+Use the specified DDS Session ID instead of the default one.
 
 * **--submission-id** *arg*  
-Specifies the Submission ID. Required for --wrkpkg and --wrkscript options.
+Specify the Submission ID. Required for --wrkpkg and --wrkscript options.
 
 * **--ignore-default-sid**  
-Force to ignore a default sid.
+Force ignoring the default session ID.
 
 * **--default-session-id**  
 Show the current default session ID.
@@ -52,23 +51,110 @@ Show the current default session ID.
 * **--default-session-id-file**  
 Show the full path of the default session ID file.
 
-* **--key *arg***  
-Gets a value for the given key from the DDS user defaults.
+* **--key** *arg*  
+Get a value for the given key from the DDS user defaults.
 
 * **--wrkpkg**  
-Shows the full path of the worker package. The path must be evaluated before use.
+Show the full path of the worker package. The path must be evaluated before use.
 
 * **--wrkscript**  
-Shows the full path of the worker script. The path must be evaluated before use.
+Show the full path of the worker script. The path must be evaluated before use.
 
 * **--rms-sandbox-dir**  
-Shows the full path of the RMS sandbox directory. It returns server.sandbox_dir if it's not empty, otherwise server.work_dir is returned. The path must be evaluated before use.
+Show the full path of the RMS sandbox directory. It returns server.sandbox_dir if it's not empty, otherwise server.work_dir is returned. The path must be evaluated before use.
 
 * **--user-env-script**  
-Shows the full path of user's environment script for workers (if present). The path must be evaluated before use.
+Show the full path of user's environment script for workers (if present). The path must be evaluated before use.
 
 * **--server-info-file**  
-Shows the full path of the DDS server info file. The path must be evaluated before use.
+Show the full path of the DDS server info file. The path must be evaluated before use.
 
 * **--session-id-file**  
-Shows the full path of the session ID file of the local environment.
+Show the full path of the session ID file of the local environment.
+
+## Examples
+
+### Show config file path
+
+```console
+$ dds-user-defaults --path
+/home/user/.DDS/DDS.cfg
+```
+
+### Generate default config file
+
+```console
+$ dds-user-defaults --default
+Generating the default DDS configuration file...
+Generating the default DDS configuration file - DONE.
+```
+
+### Generate default config file with force overwrite
+
+```console
+$ dds-user-defaults --default --force
+Generating the default DDS configuration file...
+Generating the default DDS configuration file - DONE.
+```
+
+### Get a specific configuration key value
+
+```console
+$ dds-user-defaults --key server.work_dir
+$HOME/.DDS
+
+$ dds-user-defaults --key server.log_dir
+$HOME/.DDS/log
+
+$ dds-user-defaults --key server.port_range_min
+20000
+```
+
+### Get current default session ID
+
+```console
+$ dds-user-defaults --default-session-id
+12345678-1234-1234-1234-123456789abc
+```
+
+### Get server info file path
+
+```console
+$ dds-user-defaults --server-info-file
+/home/user/.DDS/sessions/12345678-1234-1234-1234-123456789abc/server_info.cfg
+```
+
+### Get RMS sandbox directory
+
+```console
+$ dds-user-defaults --rms-sandbox-dir
+/home/user/.DDS
+```
+
+### Get worker package path
+
+```console
+$ dds-user-defaults --wrkpkg --submission-id sub123
+/home/user/.DDS/sessions/12345678-1234-1234-1234-123456789abc/wn_bins/dds-wrk-bin-3.0.0-Linux-x86_64.tar.gz
+```
+
+### Get worker script path
+
+```console
+$ dds-user-defaults --wrkscript --submission-id sub123
+/home/user/.DDS/sessions/12345678-1234-1234-1234-123456789abc/wn_bins/dds_wn_worker.sh
+```
+
+### Use custom config file
+
+```console
+$ dds-user-defaults --config /path/to/custom/DDS.cfg --key server.work_dir
+/custom/work/directory
+```
+
+### Use specific session ID
+
+```console
+$ dds-user-defaults --session 87654321-4321-4321-4321-210987654321 --session-id-file
+/home/user/.DDS/sessions/87654321-4321-4321-4321-210987654321/session_id
+```

--- a/docs/3rd-party.md
+++ b/docs/3rd-party.md
@@ -1,12 +1,16 @@
-# Building 3rd-party
+# Building 3rd-party Dependencies
 
-## BOOST Libs
+This document provides instructions for building the third-party dependencies required for DDS development.
+
+## BOOST Libraries
+
+DDS requires BOOST 1.75 or higher with C++17 support.
 
 ### BOOST on macOS
 
 ```bash
-./bootstrap.sh --prefix=[INSTALL DIR] --without-icu
-./b2 --disable-icu --prefix=[INSTALL DIR] -j8 --layout=system threading=multi link=shared,static cxxstd=17 install
+./bootstrap.sh --prefix=[INSTALL_DIR] --without-icu
+./b2 --disable-icu --prefix=[INSTALL_DIR] -j8 --layout=system threading=multi link=shared,static cxxstd=17 install
 
 cd [INSTALL_DIR]/lib
 find . -name '*.dylib' -exec bash -c 'nm=$(basename $1);install_name_tool $1 -id [INSTALL_DIR]/lib/$nm' -- {} \;
@@ -15,16 +19,37 @@ find . -name '*.dylib' -exec bash -c 'nm=$(basename $1);install_name_tool $1 -id
 ### BOOST on Linux
 
 ```bash
-./bootstrap.sh --prefix=[INSTALL DIR] --without-icu
-./b2 --disable-icu --prefix=[INSTALL DIR] -j8 --layout=system threading=multi link=shared,static cxxflags="-std=c++11" install
+./bootstrap.sh --prefix=[INSTALL_DIR] --without-icu
+./b2 --disable-icu --prefix=[INSTALL_DIR] -j8 --layout=system threading=multi link=shared,static cxxstd=17 install
 ```
 
-## clang-format
+**Note:** We recommend building boost without [ICU library](http://site.icu-project.org/) support to reduce the size of worker node packages.
 
-### clang-format on macOS
+## Code Formatting
 
-[LLVM binary builds](http://releases.llvm.org/download.html) An LLVM version 15.0.7 should be used: [Download](https://github.com/llvm/llvm-project/releases/tag/llvmorg-15.0.7)
+### clang-format
 
-### devtools-3 on CentOS
+DDS uses clang-format for consistent code formatting.
 
-[Instructions](https://www.softwarecollections.org/en/scls/rhscl/devtoolset-3/)
+#### clang-format on macOS
+
+Download from [LLVM binary builds](http://releases.llvm.org/download.html).  
+DDS requires LLVM version 15.0.7: [Download](https://github.com/llvm/llvm-project/releases/tag/llvmorg-15.0.7)
+
+#### clang-format on Linux
+
+Install via package manager or download from LLVM releases.
+
+## Development Tools
+
+### devtools-3 on CentOS/RHEL
+
+For older CentOS/RHEL systems, you may need newer development tools:
+[Software Collections Instructions](https://www.softwarecollections.org/en/scls/rhscl/devtoolset-3/)
+
+## Build Requirements Summary
+
+* C++17 compiler (GCC 7+, Clang 5+, or equivalent)
+* CMake 3.19+
+* BOOST 1.75+ (built with C++17 support)
+* clang-format 15.0.7 (for development)

--- a/docs/download.md
+++ b/docs/download.md
@@ -2,7 +2,7 @@
 
 ## Download location
 
-Please, use [DDS's Download page](http://dds.gsi.de/download.html) to get the latest version and all other versions of DDS.
+Please use [DDS's GitHub releases page](https://github.com/FairRootGroup/DDS/releases) to get the latest version and all other versions of DDS.
 
 ## DDS Version Number Scheme
 

--- a/docs/how-to-start.md
+++ b/docs/how-to-start.md
@@ -2,7 +2,7 @@
 
 ## Environment
 
-In order to enable DDS environment you need to source the DDS_env.sh script. The script is located in the directory where you installed PoD.
+In order to enable DDS environment you need to source the DDS_env.sh script. The script is located in the directory where you installed DDS.
 
 ```shell
 cd [DDS INSTALLATION]
@@ -38,12 +38,12 @@ In order to deploy agents you can use different [DDS plug-ins](../plugins/README
 
 One of the fastest way to deploy DDS is to use [the localhost plug-in](../plugins/dds-submit-localhost/README.md).
 
-But if you want to use multiple hoists, then [the SSH plug-in](../plugins/dds-submit-ssh/README.md) is the right tool.  
+But if you want to use multiple hosts, then [the SSH plug-in](../plugins/dds-submit-ssh/README.md) is the right tool.  
 When you don't have an RMS or you want to use a Cloud based system or even if you want just to use resources around you, like computers of your colleagues, then the plug-in is the best way to go.
 
 First of all you need to [define resources](../plugins/dds-submit-ssh/README.md#resource-definition).
 
-Then use `dds-submit`` to deploy DDS agents on the given resources:
+Then use `dds-submit` to deploy DDS agents on the given resources:
 
 ```shell
 dds-submit --rms ssh -c FULL_PATH_TO_YOUR_SSHPLUGIN_RESOURCE_FILE

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,5 +1,18 @@
 # Installation
 
+This guide walks you through building and installing DDS from source code. DDS supports Linux and macOS platforms.
+
+## Prerequisites
+
+Before building DDS, ensure you have:
+
+* C++17 compatible compiler (GCC 7+, Clang 5+, or equivalent)
+* CMake 3.19 or higher
+* BOOST 1.75 or higher
+* Git (for downloading source)
+
+For detailed third-party dependency information, see [Building 3rd-party Dependencies](./3rd-party.md).
+
 ## Step 1: Get the source
 
 * **From DDS git repository**
@@ -26,12 +39,12 @@ Unpack DDS tarball:
 
 You can adjust some configuration settings in the BuildSetup.cmake bootstrap file. The following is a list of variables:
 
-| Variable | Variable |
-|----------|----------|
-| CMAKE_INSTALL_PREFIX | Install path prefix, prepended onto install directories.(default ```$HOME/DDS/<DDS_Version>```)|
-| CMAKE_BUILD_TYPE | Set cmake build type. Possible options are: **None**, **Debug**, **Release**, **RelWithDebInfo**, **MinSizeRel** (default **Release**)|
-| BUILD_DOCUMENTATION | Build source code documentation. Possible options are: **ON**/**OFF** (default **OFF**)|
-| BUILD_TESTS | Build DDS tests. Possible options are: **ON**/**OFF** (default **OFF**)|
+| Variable             | Variable                                                                                                                               |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| CMAKE_INSTALL_PREFIX | Install path prefix, prepended onto install directories.(default ```$HOME/DDS/<DDS_Version>```)                                        |
+| CMAKE_BUILD_TYPE     | Set cmake build type. Possible options are: **None**, **Debug**, **Release**, **RelWithDebInfo**, **MinSizeRel** (default **Release**) |
+| BUILD_DOCUMENTATION  | Build source code documentation. Possible options are: **ON**/**OFF** (default **OFF**)                                                |
+| BUILD_TESTS          | Build DDS tests. Possible options are: **ON**/**OFF** (default **OFF**)                                                                |
 
 Now, prepare a build directory for an out-of-source build and configure the source:
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,7 +1,19 @@
 # Quick Start
 
-1. [Download DDS source tarball](./download.md).
+This guide gets you up and running with DDS in just a few steps. You'll deploy your first DDS agents and activate a sample topology.
+
+## Prerequisites
+
+* DDS successfully installed (see [Installation Guide](./install.md))
+* Terminal/shell access
+* For this example: localhost access (no additional setup required)
+
+## Steps
+
+1. [Download DDS source tarball](./download.md) or clone from GitHub.
+
 1. [Install DDS from source](./install.md).
+
 1. Enable DDS environment.
 
    ```shell
@@ -21,7 +33,7 @@
    dds-submit --rms localhost --slots 50
    ```
 
-1. Use dds-info to find out a number of agents, which are online.
+1. Use dds-info to find out the number of agents which are online.
 
    ```shell
    dds-info -n
@@ -38,3 +50,10 @@
    ```shell
    dds-topology --activate $DDS_LOCATION/tutorials/tutorial1/tutorial1_topo.xml
    ```
+
+## What's Next?
+
+* Learn more with [detailed tutorials](./tutorials.md)
+* Explore [configuration options](./user-defaults-configuration.md)  
+* Set up [resource management plugins](../plugins/README.md) for batch systems
+* Read the complete [usage guide](./how-to-start.md)

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -6,11 +6,13 @@ DDS UI/Server/WN run on Linux and Mac OS X.
 
 ### General requirements
 
-- Incoming connection on dds-commander port (configurable).
+- Incoming connection on dds-commander port (configurable via `server.commander_port_range_min` and `server.commander_port_range_max` settings).
 - A C++17 or a higher compiler.
 - [cmake](http://www.cmake.org/) 3.19 or higher.
 - [BOOST](http://www.boost.org/) 1.75 or higher.
 - shell: [BASH (or a compatible one)](http://en.wikipedia.org/wiki/Bash_(Unix_shell))
+
+For details about port configuration and other settings, see the [User Defaults Configuration Reference](user-defaults-configuration.md).
 
 ### Additional requirements for the SSH plug-in
 
@@ -18,6 +20,6 @@ DDS UI/Server/WN run on Linux and Mac OS X.
 
 ## Agents
 
-- Outgoing connection on dds-commander's port range (configurable).  
+- Outgoing connection on dds-commander's port range (configurable via `server.commander_port_range_min` and `server.commander_port_range_max` settings).  
 This is required by dds-agent to be able to connect to DDS commander server
 - shell: [BASH (or a compatible one)](http://en.wikipedia.org/wiki/Bash_(Unix_shell))

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -2,7 +2,52 @@
 
 ## Tutorial 1
 
-This tutorial demonstrates how to deploy a simple topology of 2 types of tasks (TaskTypeOne and TaskTypeTwo).  
+This tutorial demonstrates how to deAfter executing ui-custom-cmd there will be an output to the console with receiving and sending custom commands. Also check output files of tasks.
+
+## Tutorial 3
+
+This tutorial demonstrates how to use DDS in an automated script environment. It shows a complete workflow from starting a DDS session to activating a topology and cleaning up afterwards.
+
+The tutorial is provided as a shell script that automates the entire DDS workflow, making it useful for batch processing, testing, or integration with other automation tools.
+
+After DDS is installed the tutorial can be found in `$DDS_LOCATION/tutorials/tutorial3`
+
+### Tutorial 3 - Files of the tutorial
+
+* **run_tutorial3.sh**: Main automation script that demonstrates the complete DDS workflow.
+
+### Tutorial 3 - Usage example
+
+Before running the tutorial, you need to configure the script variables:
+
+1. Set the `location` variable to your DDS installation directory
+2. Set the `topologyFile` variable to point to your topology file  
+3. Set the `requiredNofAgents` variable to the number of agents needed for your topology
+
+```shell
+cd $DDS_LOCATION/tutorials/tutorial3
+# Edit run_tutorial3.sh to set proper paths and requirements
+./run_tutorial3.sh
+```
+
+### Tutorial 3 - What the script does
+
+The automation script performs the following steps:
+
+1. Sources DDS environment
+2. Starts a new DDS session
+3. Submits the required number of agents using the localhost plug-in
+4. Waits for agents to come online
+5. Activates the specified topology
+6. Runs for a specified duration (configurable)
+7. Stops the DDS session and cleans up
+
+This tutorial is particularly useful for:
+
+* Automated testing environments
+* Batch processing workflows  
+* Integration with external job schedulers
+* Learning the complete DDS command sequenceloy a simple topology of 2 types of tasks (TaskTypeOne and TaskTypeTwo).  
 By default, there will be deployed one instance of TaskTypeTwo and 5 instances of TaskTypeOne. Additionally TaskTypeTwo subscribes on key-value property from TaskTypeOne, which name is TaskIndexProperty.  
 Once TaskTypeTwo receives values of TaskIndexProperty from all TaskTypeOne, it will set the ReplyProperty property.  
 Number of instances can be changed in the topology file (`tutorial1_topo.xml`) using the `--instances` option of TaskTypeOne. Please note that number of worker nodes in the SSH-plugin configuration file (`tutorial1_hosts.cfg`) has to be changed accordingly.
@@ -30,7 +75,7 @@ Before running the tutorial make sure that:
 
 ```shell
 cd $DDS_LOCATION/tutorials/tutorial1
-dds-session start --local
+dds-session start
 dds-submit -r ssh -c tutorial1_hosts.cfg
 dds-topology --activate tutorial1_topo.xml
 ```
@@ -53,10 +98,10 @@ Before running the tutorial make sure that:
 
 ```shell
 cd $DDS_LOCATION/tutorials/tutorial2
-dds-session start --local
+dds-session start
 dds-submit -r ssh -c tutorial2_hosts.cfg
 dds-topology --activate tutorial2_topo.xml
-ui-custom-command
+ui-custom-cmd
 ```
 
 ### Tutorial 2 - Result

--- a/docs/user-defaults-configuration.md
+++ b/docs/user-defaults-configuration.md
@@ -1,0 +1,210 @@
+# DDS User Defaults Configuration Reference
+
+This document provides a comprehensive reference for all DDS user defaults configuration options. User defaults allow you to customize DDS behavior and specify various settings for the server, agents, and logging.
+
+## Overview
+
+DDS user defaults are stored in a configuration file, by default located at `~/.DDS/DDS.cfg`. You can:
+
+- Generate a default configuration file: `dds-user-defaults --default`
+- View current configuration file path: `dds-user-defaults --path`
+- Get specific configuration values: `dds-user-defaults --key <key_name>`
+- Use custom configuration file: `dds-user-defaults --config /path/to/custom.cfg`
+
+For detailed CLI usage, see the [dds-user-defaults command reference](../dds-user-defaults/README.md).
+
+## Configuration Sections
+
+### [server] Section
+
+Server-related configuration options that control DDS commander behavior.
+
+#### Core Directory Settings
+
+| Setting       | Default Value    | Description                                                                                                                                   |
+| ------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `work_dir`    | `$HOME/.DDS`     | Main working directory for DDS. All DDS data, session information, and temporary files are stored here.                                       |
+| `sandbox_dir` | `$HOME/.DDS`     | Directory used for worker packages. Useful when RMS can't access the main working directory. In most cases, should be the same as `work_dir`. |
+| `log_dir`     | `$HOME/.DDS/log` | Directory where DDS logs are stored. Each session creates a subdirectory here.                                                                |
+
+#### Logging Configuration
+
+| Setting                  | Default Value | Description                                                                                                                                                                             |
+| ------------------------ | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `log_severity_level`     | `info`        | Minimum log level to record. Options: `p_l` (protocol low), `p_m` (protocol medium), `p_h` (protocol high), `dbg` (debug), `inf` (info), `wrn` (warning), `err` (error), `fat` (fatal). |
+| `log_rotation_size`      | `10`          | Maximum log file size in MB before rotation occurs.                                                                                                                                     |
+| `log_has_console_output` | `true`        | Whether to output log messages to console in addition to log files.                                                                                                                     |
+
+#### Network Configuration
+
+| Setting                    | Default Value | Description                                                                               |
+| -------------------------- | ------------- | ----------------------------------------------------------------------------------------- |
+| `commander_port_range_min` | `20000`       | Minimum port number for DDS commander connections. Must be open for incoming connections. |
+| `commander_port_range_max` | `21000`       | Maximum port number for DDS commander connections. Must be open for incoming connections. |
+
+#### Session Management
+
+| Setting          | Default Value | Description                                                                                              |
+| ---------------- | ------------- | -------------------------------------------------------------------------------------------------------- |
+| `idle_time`      | `1800`        | Idle time in seconds after which DDS processes may be terminated by monitoring thread.                   |
+| `data_retention` | `7`           | Number of days to keep DDS sessions. Non-running sessions older than this will be automatically deleted. |
+
+#### Agent Health Monitoring
+
+| Setting                       | Default Value | Description                                                                                                     |
+| ----------------------------- | ------------- | --------------------------------------------------------------------------------------------------------------- |
+| `agent_health_check_interval` | `30`          | How often (in seconds) the Commander checks agent health status.                                                |
+| `agent_health_check_timeout`  | `30`          | Timeout in seconds for agent health checks. If an agent doesn't respond within this time, it's considered dead. |
+
+### [agent] Section
+
+Agent-related configuration options that control worker node behavior.
+
+#### Agent Directory Settings
+
+| Setting    | Default Value | Description                                                                                                                                                                                            |
+| ---------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `work_dir` | *(empty)*     | Custom working directory for agents. If empty, agents use a directory under `server.sandbox_dir`. **Note:** This option is ignored by localhost and SSH plug-ins. It's recommended to keep this empty. |
+
+#### File Permissions
+
+| Setting              | Default Value | Description                                                                                                                                                                                                                        |
+| -------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `access_permissions` | `0660`        | File permissions (in octal) applied to agent-side files, particularly user task log files (stdout/stderr). Common values: `0644` (read for all, write for owner), `0660` (read/write for owner/group), `0444` (read-only for all). |
+
+#### Resource Management
+
+| Setting                | Default Value | Description                                                                                                                   |
+| ---------------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `disk_space_threshold` | `500`         | Minimum free disk space in MB. Agent will shut down if free space falls below this threshold. Set to `0` to disable checking. |
+
+## Configuration File Example
+
+Here's a complete example configuration file with commonly used settings:
+
+```ini
+# DDS user defaults
+# version: 2.2
+
+[server]
+# Core directories
+work_dir=$HOME/.DDS
+sandbox_dir=$HOME/.DDS
+log_dir=$HOME/.DDS/log
+
+# Logging configuration
+log_severity_level=info
+log_rotation_size=10
+log_has_console_output=true
+
+# Network settings
+commander_port_range_min=20000
+commander_port_range_max=21000
+
+# Session management
+idle_time=1800
+data_retention=7
+
+# Agent health monitoring
+agent_health_check_interval=30
+agent_health_check_timeout=30
+
+[agent]
+# Agent configuration
+work_dir=
+access_permissions=0660
+disk_space_threshold=500
+```
+
+## Common Use Cases
+
+### Custom Working Directory
+
+To use a custom working directory (e.g., on a faster filesystem):
+
+```ini
+[server]
+work_dir=/fast/storage/dds
+sandbox_dir=/fast/storage/dds
+log_dir=/fast/storage/dds/log
+```
+
+### High-Performance Setup
+
+For high-throughput deployments:
+
+```ini
+[server]
+log_severity_level=wrn
+log_has_console_output=false
+agent_health_check_interval=60
+agent_health_check_timeout=60
+```
+
+### Development/Debug Setup
+
+For development and debugging:
+
+```ini
+[server]
+log_severity_level=dbg
+log_has_console_output=true
+agent_health_check_interval=10
+agent_health_check_timeout=15
+```
+
+### Restricted Network Environment
+
+For environments with limited port ranges:
+
+```ini
+[server]
+commander_port_range_min=22000
+commander_port_range_max=22010
+```
+
+## File Permissions Reference
+
+The `agent.access_permissions` setting uses octal notation:
+
+| Octal | Binary | Permission |
+| ----- | ------ | ---------- |
+| 4     | 100    | Read       |
+| 2     | 010    | Write      |
+| 1     | 001    | Execute    |
+
+Combine values for each user class (owner, group, world):
+
+- `0644`: Owner read/write, group/world read-only
+- `0660`: Owner/group read/write, world no access
+- `0755`: Owner read/write/execute, group/world read/execute
+- `0444`: Read-only for everyone
+
+## Log Severity Levels
+
+| Level           | Code  | Description                             |
+| --------------- | ----- | --------------------------------------- |
+| Protocol Low    | `p_l` | Low-level protocol events and higher    |
+| Protocol Medium | `p_m` | Medium-level protocol events and higher |
+| Protocol High   | `p_h` | High-level protocol events and higher   |
+| Debug           | `dbg` | General debug events and higher         |
+| Info            | `inf` | Informational messages and higher       |
+| Warning         | `wrn` | Warning messages and higher             |
+| Error           | `err` | Error messages and higher               |
+| Fatal           | `fat` | Fatal error messages only               |
+
+## Environment Variable Expansion
+
+Configuration values support environment variable expansion using `$VARIABLE` or `${VARIABLE}` syntax:
+
+```ini
+work_dir=$HOME/.DDS
+log_dir=${HOME}/logs/dds
+sandbox_dir=${TMPDIR}/dds-sandbox
+```
+
+## Related Documentation
+
+- [dds-user-defaults CLI Reference](../dds-user-defaults/README.md) - Command-line interface documentation
+- [How to Start](how-to-start.md) - Getting started with DDS
+- [Requirements](requirements.md) - Network and system requirements

--- a/plugins/dds-submit-slurm/README.md
+++ b/plugins/dds-submit-slurm/README.md
@@ -4,7 +4,9 @@
 
 If your home directory is not shared on the SLURM cluster, then you must define a sandbox directory, which DDS will use to store SLURM job script and all jobs' working directories will be also located there. Please note, that at the moment DDS doesn't clean jobs' working directories, therefore you are responsible to remove them if needed.
 
-In order to set sandbox directory a DDS global option `server.sandbox_dir` have to be changed, which is located in the DDS configuration file `DDS.cfg` (default location: `$HOME/.DDS/DDS.cfg`)
+In order to set sandbox directory a DDS global option `server.sandbox_dir` have to be changed, which is located in the DDS configuration file `DDS.cfg` (default location: `$HOME/.DDS/DDS.cfg`).
+
+For more details about this and other configuration options, see the [User Defaults Configuration Reference](../../docs/user-defaults-configuration.md).
 
 ## User configuration
 


### PR DESCRIPTION
- Restructure main README with clearer feature descriptions and better navigation
- Add detailed examples and usage patterns to CLI tool documentation (dds-session, dds-info, dds-topology, etc.)
- Create comprehensive user defaults configuration reference with all available options
- Update tutorials with better automation examples and clearer instructions
- Improve documentation formatting and add more practical examples throughout
- Update links to point to GitHub releases instead of legacy download pages
- Fix minor typos and improve consistency across documentation files

This update makes the documentation more user-friendly and provides better
guidance for both new users and advanced configurations.