### PR TITLE
Exclude libc / libm / ld-linux from the tarball

### DIFF
--- a/cmake/modules/DDS_CollectPrerequisites.cmake
+++ b/cmake/modules/DDS_CollectPrerequisites.cmake
@@ -27,6 +27,10 @@ include(GetPrerequisites)
         RESOLVED_DEPENDENCIES_VAR _r_deps
         UNRESOLVED_DEPENDENCIES_VAR _u_deps
         DIRECTORIES ${PREREQ_DIRS_LIST_REBUILT}
+		POST_EXCLUDE_REGEXES
+          ".*/libc\\.so\\.[0-9]+"
+          ".*/libm\\.so\\.[0-9]+"
+          ".*/ld-linux-x86-64\\.so\\.[0-9]+"
         )
 	
     foreach(_file ${_r_deps})


### PR DESCRIPTION
One cannot simply ship libc and ld-linux.so and hope they will be picked up correctly. In particular, ld-linux will always be the one of the system, because it gets loaded first by the kernel, when the executable is not yet around. This means that the current approach fails when the shipped libc is not compatible with the system ld-linux. It's much safer to simply not ship libc at all and pickup the system version.